### PR TITLE
chore: stricter e2e + aggressive-split llmlint rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,13 @@ them; `just upgrade` deliberately opts into testing latest releases.
 
 E2E visits all five routes at the Pages base path, verifies shared layout and route content, keyboard navigation, direct deep links, and the 404 fallback.
 
+The repository's LLM lint bar additionally requires every route and substantial
+feature scenario to cover happy, empty, loading, and error states in a real
+browser through both standalone-remote and host-composed paths. Its
+microfrontend architecture rule requires one Nx-bounded Module Federation
+remote per feature domain, exposed only at the app/routes boundary without
+cross-remote internal access or unrelated domains sharing a remote.
+
 ## Commits, releases, and merging
 
 Use Conventional Commits. GitHub uses squash-only merging, auto-merge, deleted head branches, and protected `master` requiring `check` and `llmlint`; admins may override.

--- a/llmlint.yml
+++ b/llmlint.yml
@@ -24,3 +24,35 @@ plugins:
   - "https://raw.githubusercontent.com/nickderobertis/dero-skills/main/skills/bootstrap/create-repo/assets/llmlint/languages/typescript.llmlint.yml@1"
   - "https://raw.githubusercontent.com/nickderobertis/dero-skills/main/skills/bootstrap/create-repo/assets/llmlint/ci.llmlint.yml@1"
   - "https://raw.githubusercontent.com/nickderobertis/dero-skills/main/skills/bootstrap/create-repo/assets/llmlint/monorepo.llmlint.yml@1"
+rules:
+  - name: changed_behavior_has_e2e
+    override: true
+    description: |
+      true ONLY when every route and every substantial feature or scenario has
+      real-browser end-to-end coverage for its happy path and its empty, loading,
+      and error states on BOTH supported render paths: the standalone Module
+      Federation remote and that remote composed into the host. Every test must
+      drive the real application through its user-visible browser interface and
+      must never mock the application under test or any app boundary whose real
+      behavior the scenario is intended to prove. false when any route,
+      substantial feature or scenario, required state, or render path lacks that
+      coverage, or when a purported end-to-end test mocks the app under test.
+
+  - name: microfrontends_split_aggressively
+    description: |
+      true when each feature domain is implemented as its own Module Federation
+      remote with a declared Nx project boundary, every remote is exposed to the
+      host only at the app/routes layer, no remote reaches into another remote's
+      internals, and no remote bundles unrelated feature domains. false when any
+      feature domain lacks its own remote or Nx boundary, a remote is exposed
+      below the app/routes layer, one remote reaches into another's internals, or
+      unrelated feature domains are bundled into one remote.
+    files:
+      include:
+        - "**/module-federation.config.*"
+        - "**/module-federation.*.config.*"
+        - "**/rspack.config.*"
+        - "**/project.json"
+    relevance: |
+      the target files configure or declare a Module Federation remote; skip
+      non-remote projects, including hosts and ordinary libraries


### PR DESCRIPTION
## What
Author the two llmlint rule changes in llmlint.yml for this repo's proof-project bar. This is a FOCUSED config task: do NOT do unrelated tooling work. (1) OVERRIDE the inherited e2e/changed-behavior rule (e.g. changed_behavior_has_e2e or e2e_not_mocked) by adding an entry with `override: true` and a tightened `description` so the rule holds true ONLY when every route AND every substantial feature/scenario has a real-browser end-to-end test covering the happy path plus empty, loading, and error states, exercised on BOTH the standalone-remote render path and the host-composed render path, driving the real app and never mocking the app under test. (2) ADD a new repo-local rule named `microfrontends_split_aggressively` with a clear true/false description: true when each feature domain is its own Module Federation remote with a declared Nx project boundary, exposed to the host only at the app/routes layer, with no remote reaching into another remote's internals and no unrelated feature domains bundled into one remote; false otherwise. Scope its files.include to module-federation configs, rspack configs, and project.json, with a `relevance` clause that skips non-remote projects. KEEP the existing scripts/oneharness-fresh.sh plumbing that makes the judge run under bypass mode. Validate the rules parse with `just lint-llm-validate` (do NOT run the diff judge here -- the stricter e2e rule cannot pass until the microfrontends land). Ensure `just check` still passes. Document both changes briefly in AGENTS.md or a linked doc.

## Why
Dispatched by ai-orchestrator (persona: `engineer`, 1 agent turn(s)), verified locally and driven to green checks before merge.
