### PR TITLE
feat(courses): courses microfrontend

### DIFF
--- a/apps/courses/src/page.tsx
+++ b/apps/courses/src/page.tsx
@@ -1,13 +1,275 @@
-import { cvDataClient } from "@site/data-access";
-export default function CoursesPage() {
+import { type Course, cvDataClient, type Resource } from "@site/data-access";
+import "@site/design-system";
+import { useEffect, useState } from "react";
+
+type CoursesView = "default" | "empty" | "error" | "loading";
+
+function requestedView(): CoursesView {
+  const value = new URLSearchParams(window.location.search).get("courses-view");
+  return value === "empty" || value === "error" || value === "loading"
+    ? value
+    : "default";
+}
+
+function useCoursesView(): CoursesView {
+  const [view, setView] = useState<CoursesView>(() => requestedView());
+  useEffect(() => {
+    if (view !== "loading") return;
+    const timer = window.setTimeout(() => setView("default"), 1_500);
+    return () => window.clearTimeout(timer);
+  }, [view]);
+  return view;
+}
+
+function ResourceTree({ resources }: { resources: Resource[] }) {
   return (
-    <section className="hero">
-      <p className="eyebrow">Nick DeRobertis</p>
-      <h1>Courses</h1>
-      <p>Course materials and teaching resources.</p>
-      <output className="placeholder">
-        Courses remote loaded · {cvDataClient.domain("courses").length} courses
-      </output>
+    <ul className="course-resource-list">
+      {resources.map((resource) => (
+        <li
+          key={`${resource.name}-${resource.author ?? ""}-${resource.url ?? ""}`}
+        >
+          {resource.url ? (
+            <a href={resource.url}>{resource.name}</a>
+          ) : (
+            <strong>{resource.name}</strong>
+          )}
+          {resource.author ? <span> by {resource.author}</span> : null}
+          {resource.description ? <p>{resource.description}</p> : null}
+          {resource.children?.length ? (
+            <ResourceTree resources={resource.children} />
+          ) : null}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function CourseDetails({ course }: { course: Course }) {
+  const gradingCategories = Object.entries(course.grading?.categories ?? {});
+  const gradeScale = Object.entries(course.grading?.scale ?? {});
+  return (
+    <div className="course-details">
+      {course.long_description ? (
+        <section className="course-pane course-overview">
+          <h3>About this course</h3>
+          <p>{course.long_description}</p>
+          {course.current_period || course.current_time ? (
+            <p>
+              <strong>Current offering:</strong>{" "}
+              {[course.current_period, course.current_time]
+                .filter(Boolean)
+                .join(" · ")}
+            </p>
+          ) : null}
+          {course.daily_prep ? (
+            <p>
+              <strong>Preparation:</strong> {course.daily_prep}
+            </p>
+          ) : null}
+        </section>
+      ) : null}
+
+      {course.textbook ? (
+        <section className="course-pane">
+          <h3>Textbook</h3>
+          <p>
+            <strong>{course.textbook.title}</strong> by {course.textbook.author}
+          </p>
+          {course.textbook.publisher_details ? (
+            <p>{course.textbook.publisher_details}</p>
+          ) : null}
+          <p>{course.textbook.required ? "Required" : "Recommended"}</p>
+          {course.textbook.description ? (
+            <p>{course.textbook.description}</p>
+          ) : null}
+        </section>
+      ) : null}
+
+      {course.prerequisites ? (
+        <section className="course-pane">
+          <h3>Prerequisites</h3>
+          {course.prerequisites.description ? (
+            <p>{course.prerequisites.description}</p>
+          ) : null}
+          {course.prerequisites.required_course_ids?.length ? (
+            <p>
+              <strong>Required:</strong>{" "}
+              {course.prerequisites.required_course_ids.join(", ")}
+            </p>
+          ) : null}
+          {course.prerequisites.recommended_course_ids?.length ? (
+            <p>
+              <strong>Recommended:</strong>{" "}
+              {course.prerequisites.recommended_course_ids.join(", ")}
+            </p>
+          ) : null}
+          {course.prerequisites.technical_skills?.length ? (
+            <>
+              <h4>Technical skills</h4>
+              <ul>
+                {course.prerequisites.technical_skills.map((skill) => (
+                  <li key={skill}>{skill}</li>
+                ))}
+              </ul>
+            </>
+          ) : null}
+          {course.prerequisites.technical_skills_description ? (
+            <p>{course.prerequisites.technical_skills_description}</p>
+          ) : null}
+        </section>
+      ) : null}
+
+      {gradingCategories.length ? (
+        <section className="course-pane">
+          <h3>Grading</h3>
+          <dl className="course-grading-categories">
+            {gradingCategories.map(([category, weight]) => (
+              <div key={category}>
+                <dt>{category}</dt>
+                <dd>{Math.round(weight * 100)}%</dd>
+              </div>
+            ))}
+          </dl>
+          {gradeScale.length ? (
+            <details>
+              <summary>View grade scale</summary>
+              <dl className="course-grade-scale">
+                {gradeScale.map(([grade, range]) => (
+                  <div key={grade}>
+                    <dt>{grade}</dt>
+                    <dd>
+                      {range.minimum}–{range.maximum}
+                    </dd>
+                  </div>
+                ))}
+              </dl>
+            </details>
+          ) : null}
+        </section>
+      ) : null}
+
+      {course.resources?.length ? (
+        <section className="course-pane course-resources">
+          <h3>Resources</h3>
+          <ResourceTree resources={course.resources} />
+        </section>
+      ) : null}
+    </div>
+  );
+}
+
+function CoursePane({ course, index }: { course: Course; index: number }) {
+  const detailsId = `course-${course.id}-details`;
+  return (
+    <article className={`course-card ${index % 2 ? "course-card-dark" : ""}`}>
+      <div className="course-summary">
+        <div>
+          <p className="course-code">{course.id.replace("-", " ")}</p>
+          <h2>{course.title}</h2>
+          {course.description ? <p>{course.description}</p> : null}
+          {course.periods_taught?.length ? (
+            <ul className="course-periods" aria-label="Periods taught">
+              {course.periods_taught.map((period) => (
+                <li key={period}>{period}</li>
+              ))}
+            </ul>
+          ) : null}
+          <dl className="course-facts">
+            {course.evaluation_score != null ? (
+              <div>
+                <dt>Evaluation score</dt>
+                <dd>
+                  {course.evaluation_score}
+                  <span> / {course.evaluation_max_score ?? 5}</span>
+                </dd>
+              </div>
+            ) : null}
+            {course.university_name ? (
+              <div>
+                <dt>University</dt>
+                <dd>{course.university_name}</dd>
+                {course.university_location ? (
+                  <dd className="course-location">
+                    {course.university_location}
+                  </dd>
+                ) : null}
+              </div>
+            ) : null}
+          </dl>
+          {course.website_url ? (
+            <a className="course-action" href={course.website_url}>
+              Course website
+            </a>
+          ) : null}
+        </div>
+        {course.topics?.length ? (
+          <section
+            className="course-topics"
+            aria-label={`${course.title} topics`}
+          >
+            <h3>Topics covered</h3>
+            <ul>
+              {course.topics.map((topic) => (
+                <li key={topic}>{topic}</li>
+              ))}
+            </ul>
+          </section>
+        ) : null}
+      </div>
+      {course.long_description ||
+      course.textbook ||
+      course.prerequisites ||
+      course.grading ||
+      course.resources?.length ? (
+        <details className="course-more" id={detailsId}>
+          <summary>Explore {course.title} details</summary>
+          <CourseDetails course={course} />
+        </details>
+      ) : null}
+    </article>
+  );
+}
+
+function CourseCollection({ courses }: { courses: Course[] }) {
+  return (
+    <section className="course-list" aria-label="Course list">
+      {courses.map((course, index) => (
+        <CoursePane course={course} index={index} key={course.id} />
+      ))}
+    </section>
+  );
+}
+
+export default function CoursesPage() {
+  const view = useCoursesView();
+  const courses = cvDataClient.domain("courses");
+  return (
+    <section className="courses-page">
+      <header className="courses-banner">
+        <p className="eyebrow">Teaching</p>
+        <h1>Courses</h1>
+        <p>
+          I’ve taught hundreds of students at multiple universities. Browse my
+          courses, topics, and teaching resources below.
+        </p>
+      </header>
+      {view === "loading" ? (
+        <div className="courses-state" role="status">
+          Loading courses…
+        </div>
+      ) : view === "error" ? (
+        <div className="courses-state courses-state-error" role="alert">
+          <h2>Courses are unavailable</h2>
+          <p>Please try again later.</p>
+        </div>
+      ) : view === "empty" ? (
+        <div className="courses-state" role="status">
+          <h2>No courses to show</h2>
+          <p>Course information will appear here when it is available.</p>
+        </div>
+      ) : (
+        <CourseCollection courses={courses} />
+      )}
     </section>
   );
 }

--- a/apps/shell-e2e/src/courses.spec.ts
+++ b/apps/shell-e2e/src/courses.spec.ts
@@ -102,28 +102,38 @@ for (const renderPath of renderPaths) {
   }) => {
     await page.setViewportSize({ width: 390, height: 844 });
     await openCourses(page, renderPath.path);
-    const summary = page
-      .getByRole("article")
-      .first()
-      .locator(".course-summary");
-    const mobileColumns = await summary.evaluate(
-      (element) =>
-        getComputedStyle(element).gridTemplateColumns.split(" ").length,
+    const course = page.getByRole("article").filter({
+      has: page.getByRole("heading", { name: "Financial Modeling" }),
+    });
+    const title = course.getByRole("heading", { name: "Financial Modeling" });
+    const topics = course.getByLabel("Financial Modeling topics");
+    const mobileTitle = await title.boundingBox();
+    const mobileTopics = await topics.boundingBox();
+    expect(mobileTitle).not.toBeNull();
+    expect(mobileTopics).not.toBeNull();
+    expect(mobileTopics?.y).toBeGreaterThan(
+      (mobileTitle?.y ?? 0) + (mobileTitle?.height ?? 0),
     );
-    expect(mobileColumns).toBe(1);
+    expect(
+      Math.abs((mobileTopics?.x ?? 0) - (mobileTitle?.x ?? 0)),
+    ).toBeLessThan(10);
 
     await page.setViewportSize({ width: 800, height: 900 });
-    const tabletColumns = await summary.evaluate(
-      (element) =>
-        getComputedStyle(element).gridTemplateColumns.split(" ").length,
+    const tabletTitle = await title.boundingBox();
+    const tabletTopics = await topics.boundingBox();
+    expect(tabletTitle).not.toBeNull();
+    expect(tabletTopics).not.toBeNull();
+    expect(tabletTopics?.x).toBeGreaterThan(
+      (tabletTitle?.x ?? 0) + (tabletTitle?.width ?? 0),
     );
-    expect(tabletColumns).toBe(2);
 
     await page.setViewportSize({ width: 1280, height: 900 });
-    const desktopColumns = await summary.evaluate(
-      (element) =>
-        getComputedStyle(element).gridTemplateColumns.split(" ").length,
+    const desktopTitle = await title.boundingBox();
+    const desktopTopics = await topics.boundingBox();
+    expect(desktopTitle).not.toBeNull();
+    expect(desktopTopics).not.toBeNull();
+    expect(desktopTopics?.x).toBeGreaterThan(
+      (desktopTitle?.x ?? 0) + (desktopTitle?.width ?? 0),
     );
-    expect(desktopColumns).toBe(2);
   });
 }

--- a/apps/shell-e2e/src/courses.spec.ts
+++ b/apps/shell-e2e/src/courses.spec.ts
@@ -1,0 +1,129 @@
+import { expect, type Page, test } from "@playwright/test";
+
+const renderPaths = [
+  { name: "host-composed", path: "courses" },
+  { name: "standalone remote", path: "remotes/courses/" },
+] as const;
+
+async function openCourses(page: Page, path: string, view?: string) {
+  await page.goto(view ? `${path}?courses-view=${view}` : path);
+  await expect(
+    page.getByRole("heading", { name: "Courses", exact: true }),
+  ).toBeVisible();
+}
+
+for (const renderPath of renderPaths) {
+  test(`${renderPath.name} renders the course list and topics from CV data`, async ({
+    page,
+  }) => {
+    await openCourses(page, renderPath.path);
+
+    await expect(
+      page.getByLabel("Course list").getByRole("article"),
+    ).toHaveCount(3);
+    const financialModeling = page.getByRole("article").filter({
+      has: page.getByRole("heading", { name: "Financial Modeling" }),
+    });
+    await expect(financialModeling.getByText("FIN 4934")).toBeVisible();
+    await expect(
+      financialModeling.getByLabel("Periods taught").getByRole("listitem"),
+    ).toHaveCount(3);
+    await expect(financialModeling.getByText(/^4.5 \/ 5$/)).toBeVisible();
+    await expect(
+      financialModeling.getByText("University of Florida", { exact: true }),
+    ).toBeVisible();
+    await expect(
+      financialModeling
+        .getByLabel("Financial Modeling topics")
+        .getByRole("listitem"),
+    ).toHaveText(["Introduction to Financial Modeling", "Corporate Valuation"]);
+  });
+
+  test(`${renderPath.name} distinguishes full and sparse course details`, async ({
+    page,
+  }) => {
+    await openCourses(page, renderPath.path);
+
+    const fullCourse = page.getByRole("article").filter({
+      has: page.getByRole("heading", { name: "Financial Modeling" }),
+    });
+    await fullCourse.getByText("Explore Financial Modeling details").click();
+    await expect(
+      fullCourse.getByRole("heading", { name: "Textbook" }),
+    ).toBeVisible();
+    await expect(
+      fullCourse.getByRole("heading", { name: "Prerequisites" }),
+    ).toBeVisible();
+    await expect(
+      fullCourse.getByRole("heading", { name: "Grading" }),
+    ).toBeVisible();
+    await expect(
+      fullCourse.getByRole("heading", { name: "Resources" }),
+    ).toBeVisible();
+    await expect(
+      fullCourse.getByRole("link", { name: "Python from Scratch" }),
+    ).toHaveAttribute("href", /waterloo/);
+
+    const sparseCourse = page.getByRole("article").filter({
+      has: page.getByRole("heading", { name: "Financial Management Lab" }),
+    });
+    await expect(sparseCourse.getByText("Spring 2014")).toBeVisible();
+    await expect(
+      sparseCourse.getByText("Virginia Commonwealth University", {
+        exact: true,
+      }),
+    ).toBeVisible();
+    await expect(sparseCourse.getByText("Evaluation score")).toHaveCount(0);
+    await expect(sparseCourse.getByText(/Explore .* details/)).toHaveCount(0);
+    await expect(
+      sparseCourse.getByLabel("Financial Management Lab topics"),
+    ).toContainText("Excel");
+  });
+
+  test(`${renderPath.name} exposes loading, empty, and error states`, async ({
+    page,
+  }) => {
+    await openCourses(page, renderPath.path, "loading");
+    await expect(page.getByRole("status")).toHaveText("Loading courses…");
+
+    await openCourses(page, renderPath.path, "empty");
+    await expect(page.getByRole("status")).toContainText("No courses to show");
+    await expect(page.getByRole("article")).toHaveCount(0);
+
+    await openCourses(page, renderPath.path, "error");
+    await expect(page.getByRole("alert")).toContainText(
+      "Courses are unavailable",
+    );
+    await expect(page.getByRole("article")).toHaveCount(0);
+  });
+
+  test(`${renderPath.name} course panes respond from mobile through desktop`, async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await openCourses(page, renderPath.path);
+    const summary = page
+      .getByRole("article")
+      .first()
+      .locator(".course-summary");
+    const mobileColumns = await summary.evaluate(
+      (element) =>
+        getComputedStyle(element).gridTemplateColumns.split(" ").length,
+    );
+    expect(mobileColumns).toBe(1);
+
+    await page.setViewportSize({ width: 800, height: 900 });
+    const tabletColumns = await summary.evaluate(
+      (element) =>
+        getComputedStyle(element).gridTemplateColumns.split(" ").length,
+    );
+    expect(tabletColumns).toBe(2);
+
+    await page.setViewportSize({ width: 1280, height: 900 });
+    const desktopColumns = await summary.evaluate(
+      (element) =>
+        getComputedStyle(element).gridTemplateColumns.split(" ").length,
+    );
+    expect(desktopColumns).toBe(2);
+  });
+}

--- a/apps/shell-e2e/src/site.spec.ts
+++ b/apps/shell-e2e/src/site.spec.ts
@@ -23,7 +23,6 @@ const pages = [
     link: "Courses",
     heading: "Courses",
     path: "courses",
-    remote: /Courses remote loaded/,
   },
 ];
 

--- a/libs/design-system/src/theme.css
+++ b/libs/design-system/src/theme.css
@@ -260,6 +260,280 @@ a {
   border-color: #ba5b5b;
   background: #fff3f3;
 }
+.courses-page {
+  display: grid;
+  gap: 0;
+}
+.courses-banner {
+  position: relative;
+  overflow: hidden;
+  margin: calc(-1 * clamp(3rem, 8vw, 7rem)) calc(50% - 50vw) 0;
+  padding: clamp(4rem, 9vw, 8rem) max(var(--space), calc((100vw - 1100px) / 2));
+  color: #fff;
+  text-align: center;
+  background:
+    linear-gradient(rgb(6 14 20 / 78%), rgb(6 14 20 / 88%)),
+    repeating-linear-gradient(8deg, #1a2830 0 2px, #111b21 2px 7px);
+}
+.courses-banner::after {
+  position: absolute;
+  inset: 10% 5% auto;
+  color: rgb(255 255 255 / 12%);
+  font:
+    italic clamp(3.5rem, 12vw, 9rem) / 1 Georgia,
+    serif;
+  content: "f(x) = Σ aₙ cos(nπx)";
+  transform: rotate(-4deg);
+  white-space: nowrap;
+}
+.courses-banner > * {
+  position: relative;
+  z-index: 1;
+}
+.courses-banner .eyebrow {
+  color: #8ed2f0;
+}
+.courses-banner h1 {
+  margin: 0.25rem 0 1rem;
+  font:
+    700 clamp(2.5rem, 7vw, 5rem) / 1 Georgia,
+    serif;
+}
+.courses-banner > p:last-child {
+  max-width: 720px;
+  margin: auto;
+  font-size: clamp(1rem, 2vw, 1.25rem);
+  line-height: 1.6;
+}
+.course-list {
+  margin: 0 calc(50% - 50vw);
+}
+.course-card {
+  padding: clamp(2.5rem, 7vw, 6rem)
+    max(var(--space), calc((100vw - 1100px) / 2));
+  background: #f5eeee;
+}
+.course-card-dark {
+  color: #f4f7f8;
+  background: #302829;
+}
+.course-summary {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(280px, 1fr);
+  gap: clamp(2rem, 7vw, 7rem);
+  align-items: start;
+}
+.course-code {
+  margin: 0 0 0.3rem;
+  color: var(--blue);
+  font-weight: 700;
+  letter-spacing: 0.06em;
+}
+.course-card-dark .course-code {
+  color: #8ed2f0;
+}
+.course-card h2 {
+  margin: 0 0 1.25rem;
+  color: var(--navy);
+  font:
+    400 clamp(2rem, 5vw, 3.5rem) / 1.05 Georgia,
+    serif;
+}
+.course-card-dark h2,
+.course-card-dark h3 {
+  color: #fff;
+}
+.course-summary > div > p:not(.course-code) {
+  max-width: 42rem;
+  line-height: 1.65;
+}
+.course-periods {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  margin: 1.5rem 0;
+  padding: 0;
+  list-style: none;
+}
+.course-periods li {
+  padding: 0.25rem 0.55rem;
+  border-radius: 999px;
+  color: #fff;
+  background: #d74c52;
+  font-size: 0.75rem;
+  font-weight: 700;
+}
+.course-facts {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2rem;
+  margin: 1.75rem 0;
+}
+.course-facts div {
+  min-width: 9rem;
+}
+.course-facts dt {
+  margin-top: 0.4rem;
+  color: var(--muted);
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.course-card-dark .course-facts dt {
+  color: #b9c6cc;
+}
+.course-facts dd {
+  margin: 0.25rem 0 0;
+  color: #268744;
+  font:
+    700 1.35rem / 1.3 Georgia,
+    serif;
+}
+.course-facts dd span,
+.course-facts div:last-child dd {
+  color: inherit;
+}
+.course-facts .course-location {
+  color: var(--muted);
+  font:
+    0.8rem / 1.4 Inter,
+    system-ui,
+    sans-serif;
+}
+.course-card-dark .course-location {
+  color: #b9c6cc;
+}
+.course-action {
+  display: inline-block;
+  padding: 0.7rem 1rem;
+  border-radius: 0.2rem;
+  color: #fff;
+  background: #d74c52;
+  font-size: 0.8rem;
+  font-weight: 700;
+  text-decoration: none;
+  text-transform: uppercase;
+}
+.course-action:hover,
+.course-action:focus-visible {
+  background: #aa3439;
+}
+.course-topics h3 {
+  margin: 0 0 1.25rem;
+  color: var(--navy);
+  font:
+    400 1.5rem / 1.2 Georgia,
+    serif;
+  text-transform: capitalize;
+}
+.course-topics ul {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+.course-topics li {
+  min-height: 8rem;
+  padding: 1.5rem;
+  color: var(--ink);
+  background: #fff;
+  box-shadow: 0 0.5rem 1.4rem rgb(18 50 74 / 14%);
+  font:
+    700 1rem / 1.4 Georgia,
+    serif;
+}
+.course-more {
+  margin-top: clamp(2rem, 6vw, 5rem);
+  border-top: 1px solid rgb(97 113 124 / 35%);
+}
+.course-more > summary {
+  width: fit-content;
+  margin: 1.5rem auto 0;
+  cursor: pointer;
+  color: var(--blue);
+  font-weight: 700;
+}
+.course-card-dark .course-more > summary {
+  color: #8ed2f0;
+}
+.course-details {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+  margin-top: 2rem;
+}
+.course-pane {
+  padding: clamp(1.25rem, 3vw, 2rem);
+  color: var(--ink);
+  background: #fff;
+  box-shadow: 0 0.3rem 1rem rgb(18 50 74 / 12%);
+}
+.course-pane h3 {
+  margin-top: 0;
+  color: var(--navy);
+  font:
+    700 1.3rem / 1.3 Georgia,
+    serif;
+}
+.course-pane h4 {
+  color: var(--navy);
+}
+.course-pane p,
+.course-pane li {
+  line-height: 1.55;
+}
+.course-overview,
+.course-resources {
+  grid-column: 1 / -1;
+}
+.course-grading-categories,
+.course-grade-scale {
+  display: grid;
+  gap: 0.35rem;
+  margin: 0 0 1rem;
+}
+.course-grading-categories div,
+.course-grade-scale div {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+}
+.course-grading-categories dd,
+.course-grade-scale dd {
+  margin: 0;
+  font-weight: 700;
+}
+.course-grade-scale {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  margin-top: 1rem;
+}
+.course-resource-list {
+  padding-left: 1.25rem;
+}
+.course-resource-list li + li {
+  margin-top: 0.45rem;
+}
+.course-resource-list p {
+  margin: 0.2rem 0 0.75rem;
+  color: var(--muted);
+}
+.courses-state {
+  margin-top: clamp(2rem, 5vw, 4rem);
+  padding: clamp(2rem, 6vw, 5rem);
+  border: 1px solid var(--line);
+  text-align: center;
+  background: var(--sky);
+}
+.courses-state h2 {
+  color: var(--navy);
+}
+.courses-state-error {
+  border-color: #ba5b5b;
+  background: #fff3f3;
+}
 .site-footer {
   border-top: 1px solid var(--line);
   color: var(--muted);
@@ -288,6 +562,17 @@ a {
   .software-stats div + div {
     border-top: 1px solid var(--line);
     border-left: 0;
+  }
+  .course-summary,
+  .course-details {
+    grid-template-columns: 1fr;
+  }
+  .course-topics ul {
+    grid-template-columns: 1fr;
+  }
+  .course-overview,
+  .course-resources {
+    grid-column: auto;
   }
 }
 @media (min-width: 701px) and (max-width: 960px) {


### PR DESCRIPTION
## What
Implement the COURSES microfrontend as a Module Federation remote with its own Nx boundary: the courses page and its banner and the course panes (title/description/periods-taught/evaluation-score/university/textbook/prerequisites/grading/topics/resources), sourcing courses from the data-access lib. Match reference/screenshots/ via design-system. Comprehensive Playwright e2e for every scenario: course list, a course with full detail vs a sparse one, topics, empty/error, responsive, standalone + host-composed. Satisfy the stricter e2e and aggressive-split llmlint rules.

## Why
Dispatched by ai-orchestrator (persona: `engineer`, 1 agent turn(s)), verified locally and driven to green checks before merge.
