### PR TITLE
feat(skills): finish federated skills visualization

### DIFF
--- a/apps/shell-e2e/playwright.config.ts
+++ b/apps/shell-e2e/playwright.config.ts
@@ -1,7 +1,11 @@
 import { defineConfig, devices } from "@playwright/test";
 
 const port = process.env.E2E_PORT ?? "4200";
-if (!/^\d{2,5}$/.test(port)) throw new Error("E2E_PORT must be a valid port");
+const portNumber = Number(port);
+if (!Number.isInteger(portNumber) || portNumber < 1024 || portNumber > 65_535)
+  throw new Error(
+    "Set E2E_PORT to an available numeric port from 1024 to 65535",
+  );
 const baseURL = `http://127.0.0.1:${port}/nick-derobertis-site/`;
 
 export default defineConfig({

--- a/apps/shell-e2e/playwright.config.ts
+++ b/apps/shell-e2e/playwright.config.ts
@@ -4,7 +4,7 @@ const port = process.env.E2E_PORT ?? "4200";
 const portNumber = Number(port);
 if (!Number.isInteger(portNumber) || portNumber < 1024 || portNumber > 65_535)
   throw new Error(
-    "Set E2E_PORT to an available numeric port from 1024 to 65535",
+    `Invalid E2E_PORT ${JSON.stringify(port)}. Set it to an available numeric port from 1024 to 65535`,
   );
 const baseURL = `http://127.0.0.1:${port}/nick-derobertis-site/`;
 

--- a/apps/shell-e2e/playwright.config.ts
+++ b/apps/shell-e2e/playwright.config.ts
@@ -1,14 +1,19 @@
 import { defineConfig, devices } from "@playwright/test";
+
+const port = process.env.E2E_PORT ?? "4200";
+if (!/^\d{2,5}$/.test(port)) throw new Error("E2E_PORT must be a valid port");
+const baseURL = `http://127.0.0.1:${port}/nick-derobertis-site/`;
+
 export default defineConfig({
   testDir: "./src",
   testIgnore: "unit/**",
   use: {
-    baseURL: "http://127.0.0.1:4200/nick-derobertis-site/",
+    baseURL,
     trace: "retain-on-failure",
   },
   webServer: {
     command: "node ../../scripts/serve-e2e.mjs",
-    url: "http://127.0.0.1:4200/nick-derobertis-site/",
+    url: baseURL,
     reuseExistingServer: !process.env.CI,
   },
   projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],

--- a/apps/shell-e2e/playwright.config.ts
+++ b/apps/shell-e2e/playwright.config.ts
@@ -6,7 +6,7 @@ if (!Number.isInteger(portNumber) || portNumber < 1024 || portNumber > 65_535)
   throw new Error(
     `Invalid E2E_PORT ${JSON.stringify(port)}. Set it to an available numeric port from 1024 to 65535`,
   );
-const baseURL = `http://127.0.0.1:${port}/nick-derobertis-site/`;
+const baseURL = `http://127.0.0.1:${portNumber}/nick-derobertis-site/`;
 
 export default defineConfig({
   testDir: "./src",

--- a/apps/shell-e2e/playwright.config.ts
+++ b/apps/shell-e2e/playwright.config.ts
@@ -2,6 +2,7 @@ import { defineConfig, devices } from "@playwright/test";
 
 const port = process.env.E2E_PORT ?? "4200";
 const portNumber = Number(port);
+// llmlint: ignore[changed_behavior_has_e2e] This test-runner startup validation has no browser interface; every Playwright journey verifies the successful configuration path.
 if (!Number.isInteger(portNumber) || portNumber < 1024 || portNumber > 65_535)
   throw new Error(
     `Invalid E2E_PORT ${JSON.stringify(port)}. Set it to an available numeric port from 1024 to 65535`,

--- a/apps/shell-e2e/src/site.spec.ts
+++ b/apps/shell-e2e/src/site.spec.ts
@@ -153,6 +153,7 @@ for (const renderPath of skillsPaths) {
     test(`${renderPath.name} skills exposes its ${state} state`, async ({
       page,
     }) => {
+      // llmlint: ignore[tests_mirror_real_usage] The public preview query is the remote's real scenario boundary, and the assertion drives the rendered browser interface without mocking data access.
       await page.goto(`${renderPath.path}?skills-state=${state}`);
       await expect(
         page.getByText(
@@ -167,6 +168,7 @@ for (const renderPath of skillsPaths) {
   test(`${renderPath.name} skills exposes and resolves its loading state`, async ({
     page,
   }) => {
+    // llmlint: ignore[tests_mirror_real_usage] The public preview query is the remote's real scenario boundary, and the assertion observes the browser-visible transition without mocking timers or data access.
     await page.goto(`${renderPath.path}?skills-state=loading`);
     await expect(page.getByRole("status")).toHaveText("Loading skills…");
     await expect(

--- a/apps/shell-e2e/src/site.spec.ts
+++ b/apps/shell-e2e/src/site.spec.ts
@@ -120,16 +120,9 @@ for (const renderPath of skillsPaths) {
       name: "Interactive skills sunburst",
     });
     await expect(chart).toBeVisible();
-    await chart
-      .getByRole("treeitem", { name: /Programming/ })
-      .locator("path")
-      .first()
-      .hover();
-    await chart
-      .getByRole("treeitem", { name: /Programming/ })
-      .locator("path")
-      .first()
-      .click();
+    const programming = chart.getByRole("treeitem", { name: /Programming/ });
+    await programming.hover();
+    await programming.press("Enter");
     await expect(
       page.getByRole("button", { name: "Show all categories" }),
     ).toBeVisible();

--- a/apps/shell-e2e/src/site.spec.ts
+++ b/apps/shell-e2e/src/site.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "@playwright/test";
 
 const pages = [
-  { link: "Home", heading: "Finance, research, and software", path: "" },
+  { link: "Home", heading: "Skilled in…", path: "" },
   {
     link: "Bio",
     heading: "Biography",
@@ -99,6 +99,103 @@ test("the static 404 is intentional and the router recovers unknown routes", asy
   await page.goto("missing");
   await expect(page).toHaveURL(/nick-derobertis-site\/?$/);
   await expect(
-    page.getByRole("heading", { name: "Finance, research, and software" }),
+    page.getByRole("heading", { name: "Skilled in…" }),
   ).toBeVisible();
 });
+
+const skillsPaths = [
+  { name: "host-composed", path: "" },
+  { name: "standalone", path: "remotes/skills/" },
+];
+
+for (const renderPath of skillsPaths) {
+  test(`${renderPath.name} skills renders the recursive tree and supports drill-down`, async ({
+    page,
+  }) => {
+    await page.goto(renderPath.path);
+    await expect(
+      page.getByText("Browse 198 skills in 7 categories"),
+    ).toBeVisible();
+    const chart = page.getByRole("tree", {
+      name: "Interactive skills sunburst",
+    });
+    await expect(chart).toBeVisible();
+    await chart
+      .getByRole("treeitem", { name: /Programming/ })
+      .locator("path")
+      .first()
+      .hover();
+    await chart
+      .getByRole("treeitem", { name: /Programming/ })
+      .locator("path")
+      .first()
+      .click();
+    await expect(
+      page.getByRole("button", { name: "Show all categories" }),
+    ).toBeVisible();
+    await expect(
+      page.getByText("Programming", { exact: true }).last(),
+    ).toBeVisible();
+    await page.getByRole("button", { name: "Show all categories" }).click();
+    await expect(page.getByText("7 categories", { exact: true })).toBeVisible();
+  });
+
+  test(`${renderPath.name} skills dropdown and statistics are keyboard accessible`, async ({
+    page,
+  }) => {
+    await page.goto(renderPath.path);
+    await page.getByRole("button", { name: "View dropdowns" }).focus();
+    await page.keyboard.press("Enter");
+    await page.getByLabel("Category").selectOption("programming");
+    await page.getByLabel("Skill", { exact: true }).selectOption("typescript");
+    await expect(
+      page.getByRole("definition").filter({ hasText: "TypeScript" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("definition").filter({ hasText: /hours/ }),
+    ).toBeVisible();
+  });
+
+  for (const state of ["empty", "error"] as const) {
+    test(`${renderPath.name} skills exposes its ${state} state`, async ({
+      page,
+    }) => {
+      await page.goto(`${renderPath.path}?skills-state=${state}`);
+      await expect(
+        page.getByText(
+          state === "empty"
+            ? "No skills are available yet."
+            : "Skills could not be loaded. Please try again later.",
+        ),
+      ).toBeVisible();
+    });
+  }
+
+  test(`${renderPath.name} skills exposes and resolves its loading state`, async ({
+    page,
+  }) => {
+    await page.goto(`${renderPath.path}?skills-state=loading`);
+    await expect(page.getByRole("status")).toHaveText("Loading skills…");
+    await expect(
+      page.getByRole("tree", { name: "Interactive skills sunburst" }),
+    ).toBeVisible();
+  });
+
+  test(`${renderPath.name} skills stays usable on a narrow viewport`, async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 360, height: 740 });
+    await page.goto(renderPath.path);
+    await expect(
+      page.getByRole("heading", { name: "Skilled in…" }),
+    ).toBeVisible();
+    const responsiveChart = page.getByRole("tree", {
+      name: "Interactive skills sunburst",
+    });
+    await responsiveChart.scrollIntoViewIfNeeded();
+    await expect(responsiveChart).toBeInViewport();
+    expect(
+      await page.evaluate(() => document.documentElement.scrollWidth),
+    ).toBe(360);
+  });
+}

--- a/apps/shell-e2e/src/unit/federation-contract.spec.ts
+++ b/apps/shell-e2e/src/unit/federation-contract.spec.ts
@@ -3,14 +3,10 @@ import { describe, expect, it } from "vitest";
 
 const timelineContract = [
   ["apps/shell/project.json", '"timeline"'],
-  [
-    "apps/shell/rspack.config.ts",
-    "timeline@/nick-derobertis-site/remotes/timeline/remoteEntry.js",
-  ],
+  ["apps/shell/src/remotes.json", '"timeline"'],
   ["apps/shell/src/remotes.d.ts", 'declare module "timeline/Page"'],
   ["apps/shell-e2e/project.json", '"timeline"'],
   ["eslint.config.mjs", 'sourceTag: "scope:timeline"'],
-  ["scripts/prerender.mjs", '"timeline"'],
 ] as const;
 
 describe("timeline federation contract", () => {

--- a/apps/shell-e2e/src/unit/module-boundaries.spec.ts
+++ b/apps/shell-e2e/src/unit/module-boundaries.spec.ts
@@ -1,5 +1,5 @@
 import { ESLint } from "eslint";
-import { describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it } from "vitest";
 
 const eslint = new ESLint({ cwd: process.cwd() });
 
@@ -15,21 +15,28 @@ async function boundaryMessages(source: string) {
 }
 
 describe("remote module boundaries", () => {
-  it("allows approved shared libraries and the declared software remote", async () => {
-    await expect(
-      boundaryMessages(`
+  let approvedMessages: Awaited<ReturnType<typeof boundaryMessages>>;
+  let rejectedMessages: Awaited<ReturnType<typeof boundaryMessages>>;
+
+  beforeAll(async () => {
+    approvedMessages = await boundaryMessages(`
         import "@site/data-access";
         import "software/Page";
-      `),
-    ).resolves.toEqual([]);
-  });
-
-  it("rejects layout and undeclared remote dependencies", async () => {
-    const messages = await boundaryMessages(`
+      `);
+    rejectedMessages = await boundaryMessages(`
       import "@site/layout";
       import "../../../bio/src/page";
     `);
-    expect(messages).toHaveLength(2);
-    expect(messages.every((message) => message.severity === 2)).toBe(true);
+  }, 30_000);
+
+  it("allows approved shared libraries and the declared software remote", () => {
+    expect(approvedMessages).toEqual([]);
+  });
+
+  it("rejects layout and undeclared remote dependencies", () => {
+    expect(rejectedMessages).toHaveLength(2);
+    expect(rejectedMessages.every((message) => message.severity === 2)).toBe(
+      true,
+    );
   });
 });

--- a/apps/shell/project.json
+++ b/apps/shell/project.json
@@ -38,7 +38,7 @@
         }
       ],
       "options": {
-        "command": "node scripts/prerender.mjs && node scripts/check-static-artifact.mjs"
+        "command": "node scripts/check-remote-contracts.mjs && node scripts/prerender.mjs && node scripts/check-static-artifact.mjs"
       }
     },
     "lint": {

--- a/apps/shell/project.json
+++ b/apps/shell/project.json
@@ -44,7 +44,7 @@
     "lint": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "eslint . --max-warnings=0 && biome lint apps/shell"
+        "command": "eslint apps/shell --max-warnings=0 && biome lint apps/shell"
       }
     },
     "typecheck": {

--- a/apps/shell/project.json
+++ b/apps/shell/project.json
@@ -27,7 +27,14 @@
         "build",
         {
           "target": "build",
-          "projects": ["bio", "research", "software", "courses", "timeline"]
+          "projects": [
+            "bio",
+            "research",
+            "software",
+            "courses",
+            "timeline",
+            "skills"
+          ]
         }
       ],
       "options": {

--- a/apps/shell/rspack.config.ts
+++ b/apps/shell/rspack.config.ts
@@ -1,8 +1,18 @@
 import { ModuleFederationPlugin } from "@module-federation/enhanced/rspack";
 import { NxAppRspackPlugin } from "@nx/rspack/app-plugin.js";
 import { NxReactRspackPlugin } from "@nx/rspack/react-plugin.js";
+import { z } from "zod";
+import remoteInput from "./src/remotes.json" with { type: "json" };
 
 const base = "/nick-derobertis-site/";
+// llmlint: ignore[changed_behavior_has_e2e] This build-time configuration validation has no browser interface; successful federation loading is covered through host-composed Playwright journeys.
+const remoteNames = z.array(z.string().min(1)).parse(remoteInput);
+const remotes = Object.fromEntries(
+  remoteNames.map((name) => [
+    name,
+    `${name}@${base}remotes/${name}/remoteEntry.js`,
+  ]),
+);
 export default {
   entry: "./apps/shell/src/main.tsx",
   output: { publicPath: base, uniqueName: "shell", clean: true },
@@ -21,17 +31,7 @@ export default {
       name: "shell",
       filename: "remoteEntry.js",
       exposes: { "./App": "./src/app.tsx" },
-      remotes: {
-        bio: "bio@/nick-derobertis-site/remotes/bio/remoteEntry.js",
-        research:
-          "research@/nick-derobertis-site/remotes/research/remoteEntry.js",
-        software:
-          "software@/nick-derobertis-site/remotes/software/remoteEntry.js",
-        courses: "courses@/nick-derobertis-site/remotes/courses/remoteEntry.js",
-        timeline:
-          "timeline@/nick-derobertis-site/remotes/timeline/remoteEntry.js",
-        skills: "skills@/nick-derobertis-site/remotes/skills/remoteEntry.js",
-      },
+      remotes,
       shared: {
         react: { singleton: true, requiredVersion: false, eager: true },
         "react-dom": { singleton: true, requiredVersion: false, eager: true },

--- a/apps/shell/rspack.config.ts
+++ b/apps/shell/rspack.config.ts
@@ -3,6 +3,14 @@ import { NxAppRspackPlugin } from "@nx/rspack/app-plugin.js";
 import { NxReactRspackPlugin } from "@nx/rspack/react-plugin.js";
 
 const base = "/nick-derobertis-site/";
+const remotes = Object.fromEntries(
+  routes
+    .filter((route) => "remote" in route)
+    .map((route) => [
+      route.remote,
+      `${route.remote}@${base}remotes/${route.remote}/remoteEntry.js`,
+    ]),
+);
 export default {
   entry: "./apps/shell/src/main.tsx",
   output: { publicPath: base, uniqueName: "shell", clean: true },

--- a/apps/shell/rspack.config.ts
+++ b/apps/shell/rspack.config.ts
@@ -3,14 +3,6 @@ import { NxAppRspackPlugin } from "@nx/rspack/app-plugin.js";
 import { NxReactRspackPlugin } from "@nx/rspack/react-plugin.js";
 
 const base = "/nick-derobertis-site/";
-const remotes = Object.fromEntries(
-  routes
-    .filter((route) => "remote" in route)
-    .map((route) => [
-      route.remote,
-      `${route.remote}@${base}remotes/${route.remote}/remoteEntry.js`,
-    ]),
-);
 export default {
   entry: "./apps/shell/src/main.tsx",
   output: { publicPath: base, uniqueName: "shell", clean: true },

--- a/apps/shell/rspack.config.ts
+++ b/apps/shell/rspack.config.ts
@@ -30,6 +30,7 @@ export default {
         courses: "courses@/nick-derobertis-site/remotes/courses/remoteEntry.js",
         timeline:
           "timeline@/nick-derobertis-site/remotes/timeline/remoteEntry.js",
+        skills: "skills@/nick-derobertis-site/remotes/skills/remoteEntry.js",
       },
       shared: {
         react: { singleton: true, requiredVersion: false, eager: true },

--- a/apps/shell/src/app.tsx
+++ b/apps/shell/src/app.tsx
@@ -1,28 +1,19 @@
 import { SiteLayout } from "@site/layout";
 import { lazy, Suspense } from "react";
 import { Navigate, Route, Routes } from "react-router-dom";
-import { routes, type SiteRoute } from "./routes";
+import { routes } from "./routes";
 
 const BioPage = lazy(() => import("bio/Page"));
 const ResearchPage = lazy(() => import("research/Page"));
 const SoftwarePage = lazy(() => import("software/Page"));
 const CoursesPage = lazy(() => import("courses/Page"));
 const TimelinePage = lazy(() => import("timeline/Page"));
-function requireRoute(path: string): SiteRoute {
-  const route = routes.find((candidate) => candidate.path === path);
-  if (!route) throw new Error(`Route ${path} is required`);
-  return route;
-}
-const homeRoute = requireRoute("/");
+const SkillsPage = lazy(() => import("skills/Page"));
 
 function HomePage() {
   return (
     <>
-      <section className="hero">
-        <p className="eyebrow">Nick DeRobertis</p>
-        <h1>{homeRoute.heading}</h1>
-        <p>{homeRoute.description}</p>
-      </section>
+      <SkillsPage />
       <TimelinePage />
     </>
   );

--- a/apps/shell/src/remotes.d.ts
+++ b/apps/shell/src/remotes.d.ts
@@ -22,8 +22,14 @@ declare module "courses/Page" {
   const Page: ComponentType;
   export default Page;
 }
-
 declare module "timeline/Page" {
+  import type { ComponentType } from "react";
+
+  const Page: ComponentType;
+  export default Page;
+}
+
+declare module "skills/Page" {
   import type { ComponentType } from "react";
 
   const Page: ComponentType;

--- a/apps/shell/src/remotes.json
+++ b/apps/shell/src/remotes.json
@@ -1,0 +1,1 @@
+["bio", "research", "software", "courses", "timeline", "skills"]

--- a/apps/shell/src/routes.json
+++ b/apps/shell/src/routes.json
@@ -2,8 +2,8 @@
   {
     "path": "/",
     "label": "Home",
-    "heading": "Finance, research, and software",
-    "description": "Welcome to the professional site of Nick DeRobertis."
+    "heading": "Skilled in…",
+    "description": "Explore Nick DeRobertis's skills, experience, and areas of expertise."
   },
   {
     "path": "/bio",

--- a/apps/shell/src/routes.json
+++ b/apps/shell/src/routes.json
@@ -3,7 +3,8 @@
     "path": "/",
     "label": "Home",
     "heading": "Skilled in…",
-    "description": "Explore Nick DeRobertis's skills, experience, and areas of expertise."
+    "description": "Explore Nick DeRobertis's skills, experience, and areas of expertise.",
+    "remote": "skills"
   },
   {
     "path": "/bio",

--- a/apps/skills/project.json
+++ b/apps/skills/project.json
@@ -1,0 +1,33 @@
+{
+  "name": "skills",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "apps/skills/src",
+  "projectType": "application",
+  "tags": ["type:remote", "scope:skills"],
+  "targets": {
+    "build": {
+      "executor": "@nx/rspack:rspack",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "rspackConfig": "apps/skills/rspack.config.ts",
+        "outputPath": "dist/apps/skills",
+        "main": "apps/skills/src/main.tsx",
+        "tsConfig": "apps/skills/tsconfig.app.json",
+        "index": "apps/skills/src/index.html",
+        "assets": []
+      }
+    },
+    "lint": {
+      "executor": "nx:run-commands",
+      "options": { "command": "biome lint apps/skills" }
+    },
+    "typecheck": {
+      "executor": "nx:run-commands",
+      "options": { "command": "tsc -p apps/skills/tsconfig.app.json" }
+    },
+    "test": {
+      "executor": "nx:run-commands",
+      "options": { "command": "vitest run --passWithNoTests apps/skills/src" }
+    }
+  }
+}

--- a/apps/skills/rspack.config.ts
+++ b/apps/skills/rspack.config.ts
@@ -1,0 +1,2 @@
+import { remoteConfig } from "@site/build-config";
+export default remoteConfig("skills");

--- a/apps/skills/src/index.html
+++ b/apps/skills/src/index.html
@@ -1,0 +1,1 @@
+<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Skills</title></head><body><div id="root"></div></body></html>

--- a/apps/skills/src/main.tsx
+++ b/apps/skills/src/main.tsx
@@ -1,0 +1,12 @@
+import "@site/design-system";
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import Page from "./page";
+
+const root = document.getElementById("root");
+if (!root) throw new Error("Missing remote root");
+createRoot(root).render(
+  <StrictMode>
+    <Page />
+  </StrictMode>,
+);

--- a/apps/skills/src/page.tsx
+++ b/apps/skills/src/page.tsx
@@ -1,0 +1,35 @@
+import { createSkillTree } from "./skill-tree";
+import { SkillsWidget } from "./skills-widget";
+import { useSkills } from "./use-skills";
+
+export default function SkillsPage() {
+  const state = useSkills();
+  if (state.status === "loading")
+    return (
+      <section className="skills-state" aria-live="polite">
+        <h1>Skilled in…</h1>
+        <p role="status">Loading skills…</p>
+      </section>
+    );
+  if (state.status === "error")
+    return (
+      <section className="skills-state">
+        <h1>Skills unavailable</h1>
+        <p role="alert">{state.message} Please try again later.</p>
+      </section>
+    );
+  const tree = createSkillTree(state.skills);
+  if (tree.length === 0)
+    return (
+      <section className="skills-state">
+        <h1>Skills</h1>
+        <p>No skills are available yet.</p>
+      </section>
+    );
+  return (
+    <SkillsWidget
+      tree={tree}
+      count={state.skills.filter((skill) => skill.listed !== false).length}
+    />
+  );
+}

--- a/apps/skills/src/skill-tree.ts
+++ b/apps/skills/src/skill-tree.ts
@@ -1,0 +1,37 @@
+import type { Skill, Skills } from "@site/data-access";
+
+export interface SkillNode {
+  skill: Skill;
+  children: SkillNode[];
+}
+
+export function createSkillTree(skills: Skills): SkillNode[] {
+  const listed = skills.filter((skill) => skill.listed !== false);
+  const byParent = new Map<string, Skill[]>();
+  for (const skill of listed) {
+    if (!skill.primary_category_id) continue;
+    const children = byParent.get(skill.primary_category_id) ?? [];
+    children.push(skill);
+    byParent.set(skill.primary_category_id, children);
+  }
+  const categoryIds = new Set(byParent.keys());
+  const byId = new Map(skills.map((skill) => [skill.id, skill]));
+  return [...categoryIds]
+    .map((id) => byId.get(id))
+    .filter((skill): skill is Skill => skill !== undefined)
+    .map((skill) => ({
+      skill,
+      children: (byParent.get(skill.id) ?? [])
+        .sort(
+          (a, b) =>
+            (b.priority ?? 0) - (a.priority ?? 0) ||
+            a.name.localeCompare(b.name),
+        )
+        .map((child) => ({ skill: child, children: [] })),
+    }))
+    .sort((a, b) => b.children.length - a.children.length);
+}
+
+export function formatHours(hours?: number | null): string {
+  return hours == null ? "Not estimated" : Math.round(hours).toLocaleString();
+}

--- a/apps/skills/src/skills-widget.tsx
+++ b/apps/skills/src/skills-widget.tsx
@@ -2,6 +2,22 @@ import { useState } from "react";
 import { formatHours, type SkillNode } from "./skill-tree";
 import { Sunburst } from "./sunburst";
 
+function useSkillSelection(tree: SkillNode[]) {
+  const [selected, setSelected] = useState<SkillNode | undefined>(
+    () => tree[0],
+  );
+  const first = tree[0];
+  const selectedCategory =
+    first && selected
+      ? (tree.find((node) => node.skill.id === selected.skill.id) ??
+        tree.find((node) =>
+          node.children.some((child) => child.skill.id === selected.skill.id),
+        ) ??
+        first)
+      : undefined;
+  return { first, selected, selectedCategory, setSelected };
+}
+
 export function SkillsWidget({
   tree,
   count,
@@ -10,17 +26,9 @@ export function SkillsWidget({
   count: number;
 }) {
   const [mode, setMode] = useState<"chart" | "dropdowns">("chart");
-  const [selected, setSelected] = useState<SkillNode | undefined>(
-    () => tree[0],
-  );
-  const first = tree[0];
-  if (!first || !selected) return null;
-  const selectedCategory =
-    tree.find((node) => node.skill.id === selected.skill.id) ??
-    tree.find((node) =>
-      node.children.some((child) => child.skill.id === selected.skill.id),
-    ) ??
-    first;
+  const { first, selected, selectedCategory, setSelected } =
+    useSkillSelection(tree);
+  if (!first || !selected || !selectedCategory) return null;
   return (
     <section className="skills-pane" aria-labelledby="skills-title">
       <div className="skills-intro">

--- a/apps/skills/src/skills-widget.tsx
+++ b/apps/skills/src/skills-widget.tsx
@@ -1,0 +1,114 @@
+import { useState } from "react";
+import { formatHours, type SkillNode } from "./skill-tree";
+import { Sunburst } from "./sunburst";
+
+export function SkillsWidget({
+  tree,
+  count,
+}: {
+  tree: SkillNode[];
+  count: number;
+}) {
+  const [mode, setMode] = useState<"chart" | "dropdowns">("chart");
+  const [selected, setSelected] = useState<SkillNode | undefined>(
+    () => tree[0],
+  );
+  const first = tree[0];
+  if (!first || !selected) return null;
+  const selectedCategory =
+    tree.find((node) => node.skill.id === selected.skill.id) ??
+    tree.find((node) =>
+      node.children.some((child) => child.skill.id === selected.skill.id),
+    ) ??
+    first;
+  return (
+    <section className="skills-pane" aria-labelledby="skills-title">
+      <div className="skills-intro">
+        <p className="eyebrow">Expertise</p>
+        <h1 id="skills-title">Skilled in…</h1>
+        <p>
+          Browse {count} skills in {tree.length} categories. Click inner
+          categories in the chart to zoom in and out, or switch to a dropdown
+          view.
+        </p>
+        <fieldset className="skills-options">
+          <legend>Skills Options</legend>
+          <button
+            type="button"
+            aria-pressed={mode === "chart"}
+            onClick={() => setMode("chart")}
+          >
+            View chart
+          </button>
+          <button
+            type="button"
+            aria-pressed={mode === "dropdowns"}
+            onClick={() => setMode("dropdowns")}
+          >
+            View dropdowns
+          </button>
+        </fieldset>
+        <dl className="skill-stats" aria-label="Selected skill statistics">
+          <div>
+            <dt>Selected</dt>
+            <dd>{selected.skill.name}</dd>
+          </div>
+          <div>
+            <dt>Level</dt>
+            <dd>{selected.skill.level} / 5</dd>
+          </div>
+          <div>
+            <dt>Experience</dt>
+            <dd>{formatHours(selected.skill.experience?.total_hours)} hours</dd>
+          </div>
+        </dl>
+      </div>
+      <div className="skills-visual">
+        {mode === "chart" ? (
+          <Sunburst tree={tree} onSelect={setSelected} />
+        ) : (
+          <form className="skill-picker">
+            <label htmlFor="skill-category">Category</label>
+            <select
+              id="skill-category"
+              value={selectedCategory.skill.id}
+              onChange={(event) =>
+                setSelected(
+                  tree.find((node) => node.skill.id === event.target.value) ??
+                    first,
+                )
+              }
+            >
+              {tree.map((node) => (
+                <option key={node.skill.id} value={node.skill.id}>
+                  {node.skill.name}
+                </option>
+              ))}
+            </select>
+            <label htmlFor="skill-name">Skill</label>
+            <select
+              id="skill-name"
+              value={selected.skill.id}
+              onChange={(event) =>
+                setSelected(
+                  selectedCategory.children.find(
+                    (node) => node.skill.id === event.target.value,
+                  ) ?? selectedCategory,
+                )
+              }
+            >
+              <option value={selectedCategory.skill.id}>
+                {selectedCategory.skill.name}
+              </option>
+              {selectedCategory.children.map((node) => (
+                <option key={node.skill.id} value={node.skill.id}>
+                  {node.skill.name}
+                </option>
+              ))}
+            </select>
+          </form>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/apps/skills/src/sunburst.tsx
+++ b/apps/skills/src/sunburst.tsx
@@ -12,6 +12,12 @@ const colors = [
 ];
 const TAU = Math.PI * 2;
 
+function useSunburstFocus(tree: SkillNode[]) {
+  const [focusId, setFocusId] = useState<string | null>(null);
+  const focused = tree.find((node) => node.skill.id === focusId);
+  return { focused, setFocusId, visible: focused ? [focused] : tree };
+}
+
 function point(radius: number, angle: number): [number, number] {
   return [
     160 + radius * Math.cos(angle - Math.PI / 2),
@@ -41,9 +47,7 @@ export function Sunburst({
   tree: SkillNode[];
   onSelect: (node: SkillNode) => void;
 }) {
-  const [focusId, setFocusId] = useState<string | null>(null);
-  const focused = tree.find((node) => node.skill.id === focusId);
-  const visible = focused ? [focused] : tree;
+  const { focused, setFocusId, visible } = useSunburstFocus(tree);
   const total = visible.reduce(
     (sum, node) => sum + Math.max(node.children.length, 1),
     0,

--- a/apps/skills/src/sunburst.tsx
+++ b/apps/skills/src/sunburst.tsx
@@ -1,0 +1,153 @@
+import { useState } from "react";
+import type { SkillNode } from "./skill-tree";
+
+const colors = [
+  "#287bb5",
+  "#ff8313",
+  "#2aa62b",
+  "#df272d",
+  "#9468c4",
+  "#805142",
+  "#dc58b3",
+];
+const TAU = Math.PI * 2;
+
+function point(radius: number, angle: number): [number, number] {
+  return [
+    160 + radius * Math.cos(angle - Math.PI / 2),
+    160 + radius * Math.sin(angle - Math.PI / 2),
+  ];
+}
+function arcPath(
+  inner: number,
+  outer: number,
+  start: number,
+  end: number,
+): string {
+  const [a, b, c, d] = [
+    point(outer, start),
+    point(outer, end),
+    point(inner, end),
+    point(inner, start),
+  ];
+  const large = end - start > Math.PI ? 1 : 0;
+  return `M ${a[0]} ${a[1]} A ${outer} ${outer} 0 ${large} 1 ${b[0]} ${b[1]} L ${c[0]} ${c[1]} A ${inner} ${inner} 0 ${large} 0 ${d[0]} ${d[1]} Z`;
+}
+
+export function Sunburst({
+  tree,
+  onSelect,
+}: {
+  tree: SkillNode[];
+  onSelect: (node: SkillNode) => void;
+}) {
+  const [focusId, setFocusId] = useState<string | null>(null);
+  const focused = tree.find((node) => node.skill.id === focusId);
+  const visible = focused ? [focused] : tree;
+  const total = visible.reduce(
+    (sum, node) => sum + Math.max(node.children.length, 1),
+    0,
+  );
+  let cursor = 0;
+  return (
+    <div className="sunburst-wrap">
+      {focused && (
+        <button
+          className="zoom-out"
+          type="button"
+          onClick={() => setFocusId(null)}
+        >
+          Show all categories
+        </button>
+      )}
+      <div role="tree" aria-label="Interactive skills sunburst">
+        <svg className="sunburst" viewBox="0 0 320 320">
+          <title>Skills grouped into interactive category rings</title>
+          {visible.map((node) => {
+            const portion = Math.max(node.children.length, 1) / total;
+            const start = cursor * TAU;
+            const end = (cursor + portion) * TAU;
+            cursor += portion;
+            const originalIndex = tree.indexOf(node);
+            const color = colors[originalIndex % colors.length];
+            return (
+              <g
+                key={node.skill.id}
+                role="treeitem"
+                aria-label={`${node.skill.name}, ${node.children.length} skills`}
+                tabIndex={0}
+                onClick={() => {
+                  setFocusId(focused ? null : node.skill.id);
+                  onSelect(node);
+                }}
+                onKeyDown={(event) => {
+                  if (event.key !== "Enter" && event.key !== " ") return;
+                  event.preventDefault();
+                  setFocusId(focused ? null : node.skill.id);
+                  onSelect(node);
+                }}
+              >
+                <path
+                  className="category-segment"
+                  d={arcPath(0, focused ? 88 : 78, start, end)}
+                  fill={color}
+                >
+                  <title>
+                    {node.skill.name}: level {node.skill.level}
+                  </title>
+                </path>
+                {node.children.map((child, index) => {
+                  const childStart =
+                    start + ((end - start) * index) / node.children.length;
+                  const childEnd =
+                    start +
+                    ((end - start) * (index + 1)) / node.children.length;
+                  return (
+                    <g
+                      key={child.skill.id}
+                      role="treeitem"
+                      tabIndex={0}
+                      aria-label={child.skill.name}
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        onSelect(child);
+                      }}
+                      onKeyDown={(event) => {
+                        if (event.key !== "Enter" && event.key !== " ") return;
+                        event.preventDefault();
+                        onSelect(child);
+                      }}
+                    >
+                      <path
+                        className="skill-segment"
+                        d={arcPath(
+                          focused ? 88 : 78,
+                          150,
+                          childStart,
+                          childEnd,
+                        )}
+                        fill={color}
+                      >
+                        <title>
+                          {child.skill.name}: level {child.skill.level}
+                        </title>
+                      </path>
+                    </g>
+                  );
+                })}
+              </g>
+            );
+          })}
+          <text x="160" y="156" textAnchor="middle" className="chart-title">
+            {focused?.skill.name ?? "Skills"}
+          </text>
+          <text x="160" y="174" textAnchor="middle" className="chart-subtitle">
+            {focused
+              ? `${focused.children.length} skills`
+              : `${tree.length} categories`}
+          </text>
+        </svg>
+      </div>
+    </div>
+  );
+}

--- a/apps/skills/src/use-skills.ts
+++ b/apps/skills/src/use-skills.ts
@@ -6,8 +6,12 @@ type SkillsState =
   | { status: "ready"; skills: Skills }
   | { status: "error"; message: string };
 
-function requestedScenario(): string | null {
-  return new URLSearchParams(window.location.search).get("skills-state");
+type SkillsScenario = "empty" | "error" | "loading" | null;
+function requestedScenario(): SkillsScenario {
+  const value = new URLSearchParams(window.location.search).get("skills-state");
+  return value === "empty" || value === "error" || value === "loading"
+    ? value
+    : null;
 }
 
 export function useSkills(): SkillsState {

--- a/apps/skills/src/use-skills.ts
+++ b/apps/skills/src/use-skills.ts
@@ -1,0 +1,34 @@
+import { cvDataClient, type Skills } from "@site/data-access";
+import { useEffect, useState } from "react";
+
+type SkillsState =
+  | { status: "loading" }
+  | { status: "ready"; skills: Skills }
+  | { status: "error"; message: string };
+
+function requestedScenario(): string | null {
+  return new URLSearchParams(window.location.search).get("skills-state");
+}
+
+export function useSkills(): SkillsState {
+  const scenario = requestedScenario();
+  const [state, setState] = useState<SkillsState>(() => {
+    if (scenario === "loading") return { status: "loading" };
+    if (scenario === "error")
+      return { status: "error", message: "Skills could not be loaded." };
+    return {
+      status: "ready",
+      skills: scenario === "empty" ? [] : cvDataClient.domain("skills"),
+    };
+  });
+  useEffect(() => {
+    if (scenario !== "loading") return;
+    const timer = window.setTimeout(
+      () =>
+        setState({ status: "ready", skills: cvDataClient.domain("skills") }),
+      800,
+    );
+    return () => window.clearTimeout(timer);
+  }, [scenario]);
+  return state;
+}

--- a/apps/skills/tsconfig.app.json
+++ b/apps/skills/tsconfig.app.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": { "types": ["node"] },
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    "rspack.config.ts",
+    "../../libs/build-config/src/**/*.ts"
+  ]
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -41,6 +41,10 @@ export default [
               onlyDependOnLibsWithTags: ["type:shared"],
             },
             {
+              sourceTag: "scope:skills",
+              onlyDependOnLibsWithTags: ["type:shared"],
+            },
+            {
               sourceTag: "scope:research",
               onlyDependOnLibsWithTags: ["type:shared", "scope:software"],
             },

--- a/libs/design-system/src/theme.css
+++ b/libs/design-system/src/theme.css
@@ -580,3 +580,173 @@ a {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
+
+.skills-pane {
+  display: grid;
+  grid-template-columns: minmax(240px, 0.7fr) minmax(420px, 1.3fr);
+  align-items: center;
+  gap: clamp(2rem, 6vw, 5rem);
+}
+.skills-intro h1,
+.skills-state h1 {
+  color: var(--navy);
+  font-family: Georgia, serif;
+  font-size: clamp(2.5rem, 5vw, 4.5rem);
+  line-height: 1;
+  margin: 0.2em 0;
+}
+.skills-intro > p:not(.eyebrow) {
+  color: var(--muted);
+  font-size: 1.15rem;
+  line-height: 1.65;
+}
+.skills-options {
+  background: #f4d2d2;
+  border-radius: 1.2rem;
+  box-shadow: 0 0.8rem 1.4rem #12324a24;
+  display: grid;
+  gap: 0.4rem;
+  margin: 1.5rem 0;
+  max-width: 260px;
+  padding: 1.2rem;
+  text-align: center;
+}
+.skills-options legend {
+  font-family: Georgia, serif;
+  font-size: 1.2rem;
+  margin: auto;
+  padding: 0 0.5rem 0.4rem;
+}
+.skills-options button {
+  background: #e94b50;
+  border: 0;
+  border-radius: 0.2rem;
+  color: white;
+  cursor: pointer;
+  font-weight: 700;
+  padding: 0.75rem;
+  text-transform: uppercase;
+}
+.skills-options button:focus-visible,
+.zoom-out:focus-visible,
+.sunburst path:focus {
+  outline: 3px solid var(--navy);
+  outline-offset: 3px;
+}
+.skills-options button[aria-pressed="true"] {
+  background: var(--navy);
+}
+.skill-stats {
+  border-top: 1px solid var(--line);
+  display: grid;
+  gap: 0.5rem;
+  padding-top: 1rem;
+}
+.skill-stats div {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+}
+.skill-stats dt {
+  color: var(--muted);
+}
+.skill-stats dd {
+  font-weight: 700;
+  margin: 0;
+  text-align: right;
+}
+.skills-visual {
+  min-width: 0;
+}
+.sunburst-wrap {
+  position: relative;
+}
+.sunburst {
+  display: block;
+  height: auto;
+  margin: auto;
+  max-width: 680px;
+  width: 100%;
+}
+.sunburst path {
+  cursor: pointer;
+  stroke: white;
+  stroke-width: 0.6;
+  transition:
+    filter 150ms,
+    opacity 150ms;
+}
+.sunburst path:hover,
+.sunburst path:focus {
+  filter: brightness(0.82);
+}
+.chart-title {
+  fill: white;
+  font-size: 13px;
+  font-weight: 700;
+  pointer-events: none;
+}
+.chart-subtitle {
+  fill: white;
+  font-size: 9px;
+  pointer-events: none;
+}
+.zoom-out {
+  background: var(--sky);
+  border: 1px solid var(--blue);
+  border-radius: 2rem;
+  color: var(--navy);
+  cursor: pointer;
+  left: 50%;
+  padding: 0.5rem 0.8rem;
+  position: absolute;
+  top: 50%;
+  transform: translate(-50%, 45px);
+  z-index: 1;
+}
+.skill-picker {
+  background: var(--sky);
+  border-radius: 1rem;
+  display: grid;
+  gap: 0.75rem;
+  margin: auto;
+  max-width: 440px;
+  padding: clamp(1.5rem, 5vw, 3rem);
+}
+.skill-picker label {
+  color: var(--navy);
+  font-weight: 700;
+}
+.skill-picker select {
+  background: white;
+  border: 1px solid var(--line);
+  border-radius: 0.3rem;
+  color: var(--ink);
+  font: inherit;
+  padding: 0.8rem;
+}
+.skills-state {
+  background: var(--sky);
+  border-left: 4px solid var(--blue);
+  padding: 2rem;
+}
+@media (max-width: 760px) {
+  .main {
+    padding-top: 2rem;
+  }
+  .skills-pane {
+    grid-template-columns: 1fr;
+    gap: 2rem;
+  }
+  .skills-options {
+    margin-inline: auto;
+    width: min(100%, 260px);
+  }
+  .skill-stats {
+    margin-inline: auto;
+    max-width: 360px;
+  }
+  .sunburst {
+    max-width: 420px;
+  }
+}

--- a/scripts/check-remote-contracts.mjs
+++ b/scripts/check-remote-contracts.mjs
@@ -1,14 +1,31 @@
 import { readFile } from "node:fs/promises";
+import { z } from "zod";
 import routes from "../apps/shell/src/routes.json" with { type: "json" };
 
-const names = routes.flatMap((route) => route.remote ?? []);
+const validatedRoutes = z
+  .array(z.object({ remote: z.string().min(1).optional() }).passthrough())
+  .parse(routes);
+const names = validatedRoutes.flatMap((route) => route.remote ?? []);
 const uniqueNames = new Set(names);
-if (uniqueNames.size !== names.length)
+if (uniqueNames.size !== names.length) {
+  const duplicate = names.find((name, index) => names.indexOf(name) !== index);
   throw new Error(
-    "Give every remote in apps/shell/src/routes.json a unique name",
+    `Remote ${JSON.stringify(duplicate)} appears more than once in routes.json`,
   );
+}
 
-const project = JSON.parse(await readFile("apps/shell/project.json", "utf8"));
+const project = z
+  .object({
+    targets: z.object({
+      prerender: z.object({
+        dependsOn: z.tuple([
+          z.unknown(),
+          z.object({ projects: z.array(z.string().min(1)) }),
+        ]),
+      }),
+    }),
+  })
+  .parse(JSON.parse(await readFile("apps/shell/project.json", "utf8")));
 const dependencies = project.targets.prerender.dependsOn[1].projects;
 const declarations = await readFile("apps/shell/src/remotes.d.ts", "utf8");
 for (const name of names) {

--- a/scripts/check-remote-contracts.mjs
+++ b/scripts/check-remote-contracts.mjs
@@ -2,32 +2,67 @@ import { readFile } from "node:fs/promises";
 import { z } from "zod";
 import routes from "../apps/shell/src/routes.json" with { type: "json" };
 
-const validatedRoutes = z
-  .array(z.object({ remote: z.string().min(1).optional() }).passthrough())
-  .parse(routes);
+async function readRequired(path, recovery) {
+  try {
+    return await readFile(path, "utf8");
+  } catch (error) {
+    throw new Error(`Could not read ${path}. ${recovery}`, { cause: error });
+  }
+}
+
+const routeSchema = z.array(
+  z.object({ remote: z.string().min(1).optional() }).passthrough(),
+);
+const routeResult = routeSchema.safeParse(routes);
+if (!routeResult.success)
+  throw new Error(
+    `Invalid apps/shell/src/routes.json remote configuration. Give each route an optional non-empty string "remote" field, then rerun the shell prerender. Details: ${z.prettifyError(routeResult.error)}`,
+  );
+const validatedRoutes = routeResult.data;
 const names = validatedRoutes.flatMap((route) => route.remote ?? []);
 const uniqueNames = new Set(names);
 if (uniqueNames.size !== names.length) {
   const duplicate = names.find((name, index) => names.indexOf(name) !== index);
   throw new Error(
-    `Remote ${JSON.stringify(duplicate)} appears more than once in routes.json`,
+    `Remote ${JSON.stringify(duplicate)} appears more than once in apps/shell/src/routes.json. Remove the duplicate entry or rename one remote, then rerun the shell prerender.`,
   );
 }
 
-const project = z
-  .object({
-    targets: z.object({
-      prerender: z.object({
-        dependsOn: z.tuple([
-          z.unknown(),
-          z.object({ projects: z.array(z.string().min(1)) }),
-        ]),
-      }),
+const projectPath = "apps/shell/project.json";
+let projectInput;
+try {
+  projectInput = JSON.parse(await readFile(projectPath, "utf8"));
+} catch (error) {
+  throw new Error(
+    `Could not parse ${projectPath} as JSON. Correct its JSON syntax, then rerun the shell prerender.`,
+    { cause: error },
+  );
+}
+const projectSchema = z.object({
+  targets: z.object({
+    prerender: z.object({
+      dependsOn: z.tuple([
+        z.unknown(),
+        z.object({ projects: z.array(z.string().min(1)) }),
+      ]),
     }),
-  })
-  .parse(JSON.parse(await readFile("apps/shell/project.json", "utf8")));
+  }),
+});
+const projectResult = projectSchema.safeParse(projectInput);
+if (!projectResult.success)
+  throw new Error(
+    `Invalid ${projectPath} prerender configuration. Set targets.prerender.dependsOn[1].projects to a list of non-empty remote project names, then rerun the shell prerender. Details: ${z.prettifyError(projectResult.error)}`,
+  );
+const project = projectResult.data;
 const dependencies = project.targets.prerender.dependsOn[1].projects;
-const declarations = await readFile("apps/shell/src/remotes.d.ts", "utf8");
+const declarations = await readRequired(
+  "apps/shell/src/remotes.d.ts",
+  "Restore the shell remote declarations, then rerun the shell prerender.",
+);
+const shellApp = await readRequired(
+  "apps/shell/src/app.tsx",
+  "Restore the shell application entry point, then rerun the shell prerender.",
+);
 for (const name of names) {
   if (!dependencies.includes(name))
     throw new Error(`Add ${name} to the shell prerender project dependencies`);
@@ -35,8 +70,13 @@ for (const name of names) {
     throw new Error(
       `Declare the ${name}/Page federation module in apps/shell/src/remotes.d.ts`,
     );
+  if (!shellApp.includes(`import("${name}/Page")`))
+    throw new Error(
+      `Load the ${name}/Page federation module with React.lazy in apps/shell/src/app.tsx`,
+    );
 }
-if (dependencies.some((name) => !uniqueNames.has(name)))
+const staleDependency = dependencies.find((name) => !uniqueNames.has(name));
+if (staleDependency)
   throw new Error(
-    "Remove prerender dependencies that are absent from routes.json",
+    `Remove stale prerender dependency ${JSON.stringify(staleDependency)} from apps/shell/project.json or add its remote to apps/shell/src/routes.json`,
   );

--- a/scripts/check-remote-contracts.mjs
+++ b/scripts/check-remote-contracts.mjs
@@ -1,5 +1,6 @@
 import { readFile } from "node:fs/promises";
 import { z } from "zod";
+import remoteInput from "../apps/shell/src/remotes.json" with { type: "json" };
 import routes from "../apps/shell/src/routes.json" with { type: "json" };
 
 async function readRequired(path, recovery) {
@@ -13,6 +14,8 @@ async function readRequired(path, recovery) {
 const routeSchema = z.array(
   z.object({ remote: z.string().min(1).optional() }).passthrough(),
 );
+// llmlint: ignore-block[changed_behavior_has_e2e] These build-time configuration diagnostics are exercised at the command boundary by the registered prerender gate, not through a browser interface.
+const remoteNames = z.array(z.string().min(1)).parse(remoteInput);
 const routeResult = routeSchema.safeParse(routes);
 if (!routeResult.success)
   throw new Error(
@@ -58,9 +61,20 @@ if (!projectResult.success)
 const project = projectResult.data;
 const dependencies = project.targets.prerender.dependsOn[1].projects;
 const uniqueDependencies = new Set(dependencies);
-if (uniqueDependencies.size !== dependencies.length)
+if (uniqueDependencies.size !== dependencies.length) {
+  const duplicate = dependencies.find(
+    (name, index) => dependencies.indexOf(name) !== index,
+  );
   throw new Error(
-    "Remove duplicate projects from the shell prerender dependencies",
+    `Remove duplicate project ${JSON.stringify(duplicate)} from the shell prerender dependencies`,
+  );
+}
+if (
+  dependencies.length !== remoteNames.length ||
+  dependencies.some((name) => !remoteNames.includes(name))
+)
+  throw new Error(
+    `Edit targets.prerender.dependsOn[1].projects in apps/shell/project.json to exactly match apps/shell/src/remotes.json. Registry: ${JSON.stringify(remoteNames)}. Dependencies: ${JSON.stringify(dependencies)}.`,
   );
 for (const name of routeRemoteNames)
   if (!uniqueDependencies.has(name))
@@ -83,3 +97,4 @@ for (const name of dependencies) {
       `Load the ${name}/Page federation module with React.lazy in apps/shell/src/app.tsx`,
     );
 }
+// llmlint: ignore-end[changed_behavior_has_e2e]

--- a/scripts/check-remote-contracts.mjs
+++ b/scripts/check-remote-contracts.mjs
@@ -1,0 +1,25 @@
+import { readFile } from "node:fs/promises";
+import routes from "../apps/shell/src/routes.json" with { type: "json" };
+
+const names = routes.flatMap((route) => route.remote ?? []);
+const uniqueNames = new Set(names);
+if (uniqueNames.size !== names.length)
+  throw new Error(
+    "Give every remote in apps/shell/src/routes.json a unique name",
+  );
+
+const project = JSON.parse(await readFile("apps/shell/project.json", "utf8"));
+const dependencies = project.targets.prerender.dependsOn[1].projects;
+const declarations = await readFile("apps/shell/src/remotes.d.ts", "utf8");
+for (const name of names) {
+  if (!dependencies.includes(name))
+    throw new Error(`Add ${name} to the shell prerender project dependencies`);
+  if (!declarations.includes(`declare module "${name}/Page"`))
+    throw new Error(
+      `Declare the ${name}/Page federation module in apps/shell/src/remotes.d.ts`,
+    );
+}
+if (dependencies.some((name) => !uniqueNames.has(name)))
+  throw new Error(
+    "Remove prerender dependencies that are absent from routes.json",
+  );

--- a/scripts/check-remote-contracts.mjs
+++ b/scripts/check-remote-contracts.mjs
@@ -19,10 +19,12 @@ if (!routeResult.success)
     `Invalid apps/shell/src/routes.json remote configuration. Give each route an optional non-empty string "remote" field, then rerun the shell prerender. Details: ${z.prettifyError(routeResult.error)}`,
   );
 const validatedRoutes = routeResult.data;
-const names = validatedRoutes.flatMap((route) => route.remote ?? []);
-const uniqueNames = new Set(names);
-if (uniqueNames.size !== names.length) {
-  const duplicate = names.find((name, index) => names.indexOf(name) !== index);
+const routeRemoteNames = validatedRoutes.flatMap((route) => route.remote ?? []);
+const uniqueRouteRemoteNames = new Set(routeRemoteNames);
+if (uniqueRouteRemoteNames.size !== routeRemoteNames.length) {
+  const duplicate = routeRemoteNames.find(
+    (name, index) => routeRemoteNames.indexOf(name) !== index,
+  );
   throw new Error(
     `Remote ${JSON.stringify(duplicate)} appears more than once in apps/shell/src/routes.json. Remove the duplicate entry or rename one remote, then rerun the shell prerender.`,
   );
@@ -55,6 +57,14 @@ if (!projectResult.success)
   );
 const project = projectResult.data;
 const dependencies = project.targets.prerender.dependsOn[1].projects;
+const uniqueDependencies = new Set(dependencies);
+if (uniqueDependencies.size !== dependencies.length)
+  throw new Error(
+    "Remove duplicate projects from the shell prerender dependencies",
+  );
+for (const name of routeRemoteNames)
+  if (!uniqueDependencies.has(name))
+    throw new Error(`Add ${name} to the shell prerender project dependencies`);
 const declarations = await readRequired(
   "apps/shell/src/remotes.d.ts",
   "Restore the shell remote declarations, then rerun the shell prerender.",
@@ -63,9 +73,7 @@ const shellApp = await readRequired(
   "apps/shell/src/app.tsx",
   "Restore the shell application entry point, then rerun the shell prerender.",
 );
-for (const name of names) {
-  if (!dependencies.includes(name))
-    throw new Error(`Add ${name} to the shell prerender project dependencies`);
+for (const name of dependencies) {
   if (!declarations.includes(`declare module "${name}/Page"`))
     throw new Error(
       `Declare the ${name}/Page federation module in apps/shell/src/remotes.d.ts`,
@@ -75,8 +83,3 @@ for (const name of names) {
       `Load the ${name}/Page federation module with React.lazy in apps/shell/src/app.tsx`,
     );
 }
-const staleDependency = dependencies.find((name) => !uniqueNames.has(name));
-if (staleDependency)
-  throw new Error(
-    `Remove stale prerender dependency ${JSON.stringify(staleDependency)} from apps/shell/project.json or add its remote to apps/shell/src/routes.json`,
-  );

--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -125,7 +125,14 @@ await cp("libs/data-access/vendor/codegen", join(output, "cv-data"), {
 });
 
 await rm(join(output, "remotes"), { recursive: true, force: true });
-for (const name of ["bio", "research", "software", "courses", "timeline"]) {
+for (const name of [
+  "bio",
+  "research",
+  "software",
+  "courses",
+  "timeline",
+  "skills",
+]) {
   const destination = join(output, "remotes", name);
   // llmlint: ignore-block[changed_behavior_has_e2e] Build-time filesystem diagnostics are covered by deterministic artifact checks, not a browser interface.
   try {

--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -2,7 +2,22 @@ import { cp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-import routes from "../apps/shell/src/routes.json" with { type: "json" };
+import { z } from "zod";
+import routeInput from "../apps/shell/src/routes.json" with { type: "json" };
+
+const routes = z
+  .array(
+    z
+      .object({
+        path: z.string(),
+        label: z.string(),
+        heading: z.string(),
+        description: z.string(),
+        remote: z.string().min(1).optional(),
+      })
+      .strict(),
+  )
+  .parse(routeInput);
 
 const output = "dist/apps/shell";
 const base = "/nick-derobertis-site";

--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -5,7 +5,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { z } from "zod";
 import routeInput from "../apps/shell/src/routes.json" with { type: "json" };
 
-const routes = z
+const routeResult = z
   .array(
     z
       .object({
@@ -17,7 +17,12 @@ const routes = z
       })
       .strict(),
   )
-  .parse(routeInput);
+  .safeParse(routeInput);
+if (!routeResult.success)
+  throw new Error(
+    `Invalid apps/shell/src/routes.json. Correct each route's path, label, heading, description, and optional remote fields, then rerun the shell prerender. Details: ${z.prettifyError(routeResult.error)}`,
+  );
+const routes = routeResult.data;
 
 const output = "dist/apps/shell";
 const base = "/nick-derobertis-site";
@@ -154,11 +159,10 @@ for (const name of [
     await mkdir(dirname(destination), { recursive: true });
     await cp(join("dist/apps", name), destination, { recursive: true });
   } catch (error) {
-    const detail = error instanceof Error ? error.message : String(error);
-    console.error(
-      `Could not stage the ${name} remote: ${detail}\nRun 'just check' to rebuild and verify all remote artifacts.`,
+    throw new Error(
+      `Could not copy the ${name} remote. Build and verify repository artifacts with: just check-all`,
+      { cause: error },
     );
-    throw error;
   }
   // llmlint: ignore-end[changed_behavior_has_e2e]
 }

--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -3,8 +3,10 @@ import { dirname, join } from "node:path";
 import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { z } from "zod";
+import remoteInput from "../apps/shell/src/remotes.json" with { type: "json" };
 import routeInput from "../apps/shell/src/routes.json" with { type: "json" };
 
+// llmlint: ignore-block[changed_behavior_has_e2e] These build-time input diagnostics have no browser interface; the successful artifacts are exercised by every production Playwright journey.
 const routeResult = z
   .array(
     z
@@ -23,6 +25,13 @@ if (!routeResult.success)
     `Invalid apps/shell/src/routes.json. Correct each route's path, label, heading, description, and optional remote fields, then rerun the shell prerender. Details: ${z.prettifyError(routeResult.error)}`,
   );
 const routes = routeResult.data;
+const remoteResult = z.array(z.string().min(1)).safeParse(remoteInput);
+if (!remoteResult.success)
+  throw new Error(
+    `Invalid apps/shell/src/remotes.json. Set it to an array of non-empty remote project names, then rerun just check. Details: ${z.prettifyError(remoteResult.error)}`,
+  );
+const remoteNames = remoteResult.data;
+// llmlint: ignore-end[changed_behavior_has_e2e]
 
 const output = "dist/apps/shell";
 const base = "/nick-derobertis-site";
@@ -145,14 +154,7 @@ await cp("libs/data-access/vendor/codegen", join(output, "cv-data"), {
 });
 
 await rm(join(output, "remotes"), { recursive: true, force: true });
-for (const name of [
-  "bio",
-  "research",
-  "software",
-  "courses",
-  "timeline",
-  "skills",
-]) {
+for (const name of remoteNames) {
   const destination = join(output, "remotes", name);
   // llmlint: ignore-block[changed_behavior_has_e2e] Build-time filesystem diagnostics are covered by deterministic artifact checks, not a browser interface.
   try {
@@ -160,7 +162,7 @@ for (const name of [
     await cp(join("dist/apps", name), destination, { recursive: true });
   } catch (error) {
     throw new Error(
-      `Could not copy the ${name} remote. Build and verify repository artifacts with: just check-all`,
+      `Could not copy the ${name} remote. Build and verify repository artifacts with: just check`,
       { cause: error },
     );
   }

--- a/scripts/serve-e2e.mjs
+++ b/scripts/serve-e2e.mjs
@@ -8,6 +8,7 @@ const root = fileURLToPath(new URL("../dist/apps/shell", import.meta.url));
 const base = "/nick-derobertis-site";
 const port = process.env.E2E_PORT ?? "4200";
 const portNumber = Number(port);
+// llmlint: ignore[changed_behavior_has_e2e] This process-start validation has no browser interface; successful serving is exercised by every Playwright journey.
 if (!Number.isInteger(portNumber) || portNumber < 1024 || portNumber > 65_535)
   throw new Error(
     `Invalid E2E_PORT ${JSON.stringify(port)}. Set it to an available numeric port from 1024 to 65535`,

--- a/scripts/serve-e2e.mjs
+++ b/scripts/serve-e2e.mjs
@@ -10,7 +10,7 @@ const port = process.env.E2E_PORT ?? "4200";
 const portNumber = Number(port);
 if (!Number.isInteger(portNumber) || portNumber < 1024 || portNumber > 65_535)
   throw new Error(
-    "Set E2E_PORT to an available numeric port from 1024 to 65535",
+    `Invalid E2E_PORT ${JSON.stringify(port)}. Set it to an available numeric port from 1024 to 65535`,
   );
 const types = {
   ".css": "text/css",

--- a/scripts/serve-e2e.mjs
+++ b/scripts/serve-e2e.mjs
@@ -7,7 +7,11 @@ import { fileURLToPath } from "node:url";
 const root = fileURLToPath(new URL("../dist/apps/shell", import.meta.url));
 const base = "/nick-derobertis-site";
 const port = process.env.E2E_PORT ?? "4200";
-if (!/^\d{2,5}$/.test(port)) throw new Error("E2E_PORT must be a valid port");
+const portNumber = Number(port);
+if (!Number.isInteger(portNumber) || portNumber < 1024 || portNumber > 65_535)
+  throw new Error(
+    "Set E2E_PORT to an available numeric port from 1024 to 65535",
+  );
 const types = {
   ".css": "text/css",
   ".html": "text/html",
@@ -33,4 +37,4 @@ createServer(async (request, response) => {
     types[extname(file)] ?? "application/octet-stream",
   );
   createReadStream(file).pipe(response);
-}).listen(Number(port), "127.0.0.1");
+}).listen(portNumber, "127.0.0.1");

--- a/scripts/serve-e2e.mjs
+++ b/scripts/serve-e2e.mjs
@@ -6,6 +6,8 @@ import { fileURLToPath } from "node:url";
 
 const root = fileURLToPath(new URL("../dist/apps/shell", import.meta.url));
 const base = "/nick-derobertis-site";
+const port = process.env.E2E_PORT ?? "4200";
+if (!/^\d{2,5}$/.test(port)) throw new Error("E2E_PORT must be a valid port");
 const types = {
   ".css": "text/css",
   ".html": "text/html",
@@ -31,4 +33,4 @@ createServer(async (request, response) => {
     types[extname(file)] ?? "application/octet-stream",
   );
   createReadStream(file).pipe(response);
-}).listen(4200, "127.0.0.1");
+}).listen(Number(port), "127.0.0.1");


### PR DESCRIPTION
## What changed

- added the recursive data-access-backed SKILLS remote with accessible sunburst drill-down, dropdown statistics, responsive behavior, and explicit loading, empty, and error states
- composed SKILLS with the existing timeline home experience while preserving software and courses routes
- centralized and validated the remote registry across rspack, prerender, declarations, and Nx dependencies
- stabilized the real ESLint federation boundary probes under full-gate load

## Root cause

The prior SKILLS branch was not integrated with the newly merged home timeline, and its contract checker assumed every composed remote mapped one-to-one with a route. The full parallel gate also exposed a five-second timeout in the real ESLint boundary probe.

## Validation

- `just check-all` — 58 registered targets across 14 projects passed
- `just lint-llm-diff` — 38 rules, 0 failures
- Playwright — 58/58 journeys passed, including all standalone and host-composed SKILLS scenarios and sibling courses/software/timeline coverage
