### PR TITLE
feat(bio): implement story microfrontend

### DIFF
--- a/apps/bio/src/page.tsx
+++ b/apps/bio/src/page.tsx
@@ -1,14 +1,163 @@
 import { cvDataClient } from "@site/data-access";
-export default function BioPage() {
-  return (
-    <section className="hero">
-      <p className="eyebrow">Nick DeRobertis</p>
-      <h1>Biography</h1>
-      <p>Professor, researcher, and open-source software developer.</p>
-      <output className="placeholder">
-        Biography remote loaded · {cvDataClient.domain("timeline").length}{" "}
-        timeline entries
-      </output>
-    </section>
+import "@site/design-system";
+import { useEffect, useState } from "react";
+
+type BioView = "default" | "empty" | "error" | "loading";
+
+function requestedView(): BioView {
+  const value = new URLSearchParams(window.location.search).get("bio-view");
+  return value === "empty" || value === "error" || value === "loading"
+    ? value
+    : "default";
+}
+
+function useBioView(): BioView {
+  const [view, setView] = useState<BioView>(() => requestedView());
+  useEffect(() => {
+    if (view !== "loading") return;
+    const timer = window.setTimeout(() => setView("default"), 1_500);
+    return () => window.clearTimeout(timer);
+  }, [view]);
+  return view;
+}
+
+function Story() {
+  const timeline = cvDataClient.domain("timeline");
+  const doctorate = timeline.find(
+    (entry) => entry.kind === "education" && entry.short_degree === "Ph.D.",
   );
+  const organizations = new Set(
+    timeline
+      .filter((entry) => entry.kind !== "education")
+      .map((entry) => entry.organization),
+  );
+
+  return (
+    <article className="bio-story" aria-label="Nick DeRobertis's story">
+      <section className="bio-cover" aria-label="Biography cover">
+        <div className="bio-cover-content">
+          <p className="eyebrow">The story so far</p>
+          <h1>Optimizing Life</h1>
+          <p>
+            Finance professor, researcher, entrepreneur, and open-source
+            software developer.
+          </p>
+          <dl className="bio-facts" aria-label="Biography highlights">
+            <div>
+              <dt>Doctorate</dt>
+              <dd>{doctorate?.organization ?? "University of Florida"}</dd>
+            </div>
+            <div>
+              <dt>Career</dt>
+              <dd>{organizations.size} organizations</dd>
+            </div>
+          </dl>
+        </div>
+      </section>
+
+      <section className="bio-prose" aria-label="Biography prose">
+        <section>
+          <h2>Early Days</h2>
+          <p>
+            I was born and raised in Virginia and from an early age I realized I
+            only had limited time on this planet. Since then I have sought every
+            day to maximize my impact on the world and get the most enjoyment
+            out of life.
+          </p>
+        </section>
+
+        <section>
+          <h2>Philosophy</h2>
+          <h3>Continuous Learning, Innovation, and Open Collaboration</h3>
+          <p>
+            When taking on a project, I always try to learn something new and
+            usually develop some tools along the way. In trying to maximize my
+            impact, I have open-sourced many of these tools. My hope is that the
+            net productivity gain to the finance, data science, and software
+            development industries from open-sourcing these tools will be far
+            greater than the amount of work I could produce alone. If everyone
+            agrees to collaborate openly rather than keeping tools or knowledge
+            for themselves or teams, then society will be much better off as a
+            whole.
+          </p>
+        </section>
+
+        <section>
+          <h2>Reproducible Research</h2>
+          <p>
+            Another reason for my focus on software and automation is because I
+            believe we would gain much more understanding of finance if our
+            research studies were consistently open and reproducible.
+          </p>
+          <h3 className="bio-problem">The Problem</h3>
+          <p>
+            Our studies often require complex manipulations of data for
+            cleaning, merging, aggregating, analyzing, and visualizing. A
+            research project that completes all of its stages from raw data to
+            publication and presentation, in well-organized, modular, readable
+            code currently easily spans tens of thousands of lines of code.
+            Asking someone who also needs to know statistics, econometrics,
+            economic theory, visualization, writing, and presentation to learn
+            the level of software engineering skill currently required to
+            execute this is too much of a burden for most.
+          </p>
+          <h3 className="bio-solution">The Solution</h3>
+          <p>
+            Automation, open source software, and version control are the keys
+            to this future. An empirical research project should be able to run
+            from the raw data sources to the full analysis, publication, and
+            presentation by executing a single line of code and this is how I
+            structure all my projects. The code and data should be submitted
+            along with a journal submission and the reviewer should reproduce
+            the results and inspect the code and data.
+          </p>
+          <p>
+            To make our research reproducible, some empirical researchers need
+            to put a greater focus on software which automates the more
+            difficult parts of the process and share it openly with the world.
+            Then research projects could be completed with far less code and be
+            automatically reproducible. I hope to do my part towards this end
+            while also completing research and teaching.
+          </p>
+        </section>
+
+        <section>
+          <h2>Day to Day</h2>
+          <p>
+            I spend most of my time researching finance topics, teaching, and
+            building these tools, but when I get some extra time I love to work
+            with my hands and experience the outdoors. I have been maintaining
+            our family’s vehicles since 2009 and take any chance I can get to go
+            hiking or camping. My wife and I are currently traveling around the
+            U.S. with our cat and dog.
+          </p>
+        </section>
+      </section>
+    </article>
+  );
+}
+
+export default function BioPage() {
+  const view = useBioView();
+  if (view === "loading")
+    return (
+      <div className="bio-state" role="status">
+        Loading biography…
+      </div>
+    );
+  if (view === "error")
+    return (
+      <div className="bio-state bio-state-error" role="alert">
+        <h1>Biography unavailable</h1>
+        <p>Please try again later.</p>
+      </div>
+    );
+  if (view === "empty")
+    return (
+      <div className="bio-state" role="status">
+        <h1>Biography coming soon</h1>
+        <p>There is no story to show yet.</p>
+      </div>
+    );
+  return <Story />;
 }

--- a/apps/shell-e2e/playwright.config.ts
+++ b/apps/shell-e2e/playwright.config.ts
@@ -1,15 +1,35 @@
 import { defineConfig, devices } from "@playwright/test";
+
+const e2eBasePath = "/nick-derobertis-site";
+if (!/^\/[a-z0-9-]+$/.test(e2eBasePath))
+  throw new Error(
+    "The e2e base path must start with / and contain only lowercase letters, digits, and hyphens; update e2eBasePath in the Playwright config",
+  );
+const port =
+  10_000 +
+  [...process.cwd()].reduce(
+    (hash, character) => (hash * 31 + character.charCodeAt(0)) % 40_000,
+    0,
+  );
+const serverUrl = `http://127.0.0.1:${port}${e2eBasePath}/`;
+const isCi = process.env.CI === "1" || process.env.CI === "true";
+
 export default defineConfig({
   testDir: "./src",
   testIgnore: "unit/**",
   use: {
-    baseURL: "http://127.0.0.1:4200/nick-derobertis-site/",
+    baseURL: serverUrl,
     trace: "retain-on-failure",
   },
   webServer: {
     command: "node ../../scripts/serve-e2e.mjs",
-    url: "http://127.0.0.1:4200/nick-derobertis-site/",
-    reuseExistingServer: !process.env.CI,
+    env: {
+      ...process.env,
+      SITE_E2E_BASE_PATH: e2eBasePath,
+      SITE_E2E_PORT: String(port),
+    },
+    url: serverUrl,
+    reuseExistingServer: !isCi,
   },
   projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
 });

--- a/apps/shell-e2e/src/bio.spec.ts
+++ b/apps/shell-e2e/src/bio.spec.ts
@@ -1,0 +1,93 @@
+import { expect, type Page, test } from "@playwright/test";
+
+const renderPaths = [
+  { name: "host-composed", path: "bio" },
+  { name: "standalone remote", path: "remotes/bio/" },
+] as const;
+
+async function openBio(page: Page, path: string, view?: string) {
+  await page.goto(view ? `${path}?bio-view=${view}` : path);
+  await expect(
+    page.getByRole("heading", { name: "Optimizing Life" }),
+  ).toBeVisible();
+}
+
+for (const renderPath of renderPaths) {
+  test(`${renderPath.name} renders the complete story and structured highlights`, async ({
+    page,
+  }) => {
+    await openBio(page, renderPath.path);
+
+    await expect(page.getByLabel("Nick DeRobertis's story")).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Early Days" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Philosophy" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Reproducible Research" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Day to Day" }),
+    ).toBeVisible();
+    await expect(page.getByLabel("Biography highlights")).toContainText(
+      "University of Florida",
+    );
+    await expect(
+      page.getByText(/tens of thousands of lines of code/),
+    ).toBeVisible();
+  });
+
+  test(`${renderPath.name} exposes loading, empty, and error states`, async ({
+    page,
+  }) => {
+    await page.goto(`${renderPath.path}?bio-view=loading`);
+    await expect(page.getByRole("status")).toHaveText("Loading biography…");
+    await expect(
+      page.getByRole("heading", { name: "Optimizing Life" }),
+    ).toBeVisible();
+
+    await page.goto(`${renderPath.path}?bio-view=empty`);
+    await expect(page.getByRole("status")).toContainText(
+      "Biography coming soon",
+    );
+
+    await page.goto(`${renderPath.path}?bio-view=error`);
+    await expect(page.getByRole("alert")).toContainText(
+      "Biography unavailable",
+    );
+  });
+
+  test(`${renderPath.name} story responds from mobile through desktop`, async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await openBio(page, renderPath.path);
+    const cover = page.getByLabel("Biography cover");
+    const prose = page.getByRole("region", { name: "Biography prose" });
+    const mobileCover = await cover.boundingBox();
+    const mobileProse = await prose.boundingBox();
+    expect(mobileCover).not.toBeNull();
+    expect(mobileProse).not.toBeNull();
+    expect(mobileCover?.width).toBeLessThanOrEqual(390);
+    expect(mobileProse?.width).toBeLessThanOrEqual(390);
+
+    await page.setViewportSize({ width: 1280, height: 900 });
+    const desktopCover = await cover.boundingBox();
+    const desktopProse = await prose.boundingBox();
+    expect(desktopCover?.width).toBeGreaterThan(mobileCover?.width ?? 0);
+    expect(desktopProse?.width).toBeGreaterThan(mobileProse?.width ?? 0);
+    expect(desktopProse?.width).toBeLessThan(850);
+  });
+}
+
+test("legacy story route redirects to the host-composed biography", async ({
+  page,
+}) => {
+  await page.goto("story");
+  await expect(page).toHaveURL(/\/bio$/);
+  await expect(
+    page.getByRole("heading", { name: "Optimizing Life" }),
+  ).toBeVisible();
+});

--- a/apps/shell-e2e/src/site.spec.ts
+++ b/apps/shell-e2e/src/site.spec.ts
@@ -6,7 +6,6 @@ const pages = [
     link: "Bio",
     heading: "Biography",
     path: "bio",
-    remote: /Biography remote loaded/,
   },
   {
     link: "Research",

--- a/apps/shell-e2e/src/site.spec.ts
+++ b/apps/shell-e2e/src/site.spec.ts
@@ -4,7 +4,7 @@ const pages = [
   { link: "Home", heading: "Finance, research, and software", path: "" },
   {
     link: "Bio",
-    heading: "Biography",
+    heading: "Optimizing Life",
     path: "bio",
   },
   {
@@ -72,7 +72,9 @@ test("navigation works with the keyboard", async ({ page }) => {
   await page.getByRole("link", { name: "Bio" }).focus();
   await page.keyboard.press("Enter");
   await expect(page).toHaveURL(/\/bio$/);
-  await expect(page.getByRole("heading", { name: "Biography" })).toBeVisible();
+  await expect(
+    page.getByRole("heading", { name: "Optimizing Life" }),
+  ).toBeVisible();
 });
 
 test("a remote consumes another remote", async ({ page }) => {

--- a/apps/shell-e2e/src/unit/module-boundaries.spec.ts
+++ b/apps/shell-e2e/src/unit/module-boundaries.spec.ts
@@ -22,7 +22,7 @@ describe("remote module boundaries", () => {
         import "software/Page";
       `),
     ).resolves.toEqual([]);
-  });
+  }, 30_000);
 
   it("rejects layout and undeclared remote dependencies", async () => {
     const messages = await boundaryMessages(`

--- a/apps/shell/src/app.tsx
+++ b/apps/shell/src/app.tsx
@@ -40,6 +40,7 @@ export function App() {
         <Routes>
           <Route path="/" element={<HomePage />} />
           <Route path="/bio" element={<BioPage />} />
+          <Route path="/story" element={<Navigate to="/bio" replace />} />
           <Route path="/research" element={<ResearchPage />} />
           <Route path="/software" element={<SoftwarePage />} />
           <Route path="/courses" element={<CoursesPage />} />

--- a/apps/shell/src/routes.json
+++ b/apps/shell/src/routes.json
@@ -8,7 +8,7 @@
   {
     "path": "/bio",
     "label": "Bio",
-    "heading": "Biography",
+    "heading": "Optimizing Life",
     "description": "Professor, researcher, and open-source software developer.",
     "remote": "bio"
   },

--- a/libs/design-system/src/theme.css
+++ b/libs/design-system/src/theme.css
@@ -94,6 +94,131 @@ a {
   border-left: 4px solid var(--blue);
   background: var(--sky);
 }
+.bio-story {
+  margin: calc(-1 * clamp(3rem, 8vw, 7rem)) calc(50% - 50vw);
+  background: #f8f5f2;
+}
+.bio-cover {
+  position: relative;
+  display: grid;
+  min-height: clamp(28rem, 66vh, 42rem);
+  place-items: center;
+  overflow: hidden;
+  padding: clamp(4rem, 10vw, 8rem) var(--space);
+  color: #fff;
+  background-color: #251428;
+  background-image:
+    linear-gradient(135deg, rgb(23 9 28 / 48%), rgb(69 20 25 / 42%)),
+    linear-gradient(
+      45deg,
+      transparent 25%,
+      rgb(209 57 64 / 22%) 25% 50%,
+      transparent 50%
+    ),
+    linear-gradient(
+      -45deg,
+      transparent 25%,
+      rgb(40 120 168 / 18%) 25% 50%,
+      transparent 50%
+    );
+  background-size:
+    auto,
+    18rem 18rem,
+    22rem 22rem;
+}
+.bio-cover::after {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(transparent 45%, rgb(12 8 14 / 38%));
+  content: "";
+}
+.bio-cover-content {
+  position: relative;
+  z-index: 1;
+  width: min(760px, 100%);
+  text-align: center;
+}
+.bio-cover .eyebrow {
+  color: #f38589;
+}
+.bio-cover h1 {
+  margin: 0.2em 0;
+  font:
+    700 clamp(3rem, 9vw, 6.5rem) / 0.95 Georgia,
+    serif;
+}
+.bio-cover-content > p:last-of-type {
+  max-width: 650px;
+  margin: 1.5rem auto 2.5rem;
+  font-size: clamp(1.05rem, 2vw, 1.3rem);
+  line-height: 1.6;
+}
+.bio-facts {
+  display: flex;
+  justify-content: center;
+  gap: clamp(2rem, 8vw, 6rem);
+  margin: 0;
+}
+.bio-facts div {
+  min-width: 9rem;
+}
+.bio-facts dt {
+  color: #f38589;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+.bio-facts dd {
+  margin: 0.4rem 0 0;
+  font:
+    700 1.1rem / 1.3 Georgia,
+    serif;
+}
+.bio-prose {
+  width: min(820px, calc(100% - 2 * var(--space)));
+  margin: auto;
+  padding: clamp(3rem, 8vw, 7rem) 0;
+}
+.bio-prose section + section {
+  margin-top: clamp(2.5rem, 6vw, 4.5rem);
+}
+.bio-prose h2 {
+  margin: 0 0 1rem;
+  color: var(--navy);
+  font:
+    700 clamp(1.8rem, 4vw, 2.5rem) / 1.2 Georgia,
+    serif;
+}
+.bio-prose h3 {
+  margin: 2rem 0 0.75rem;
+  color: var(--navy);
+  font-size: 1.15rem;
+}
+.bio-prose p {
+  margin: 0.75rem 0;
+  font-size: clamp(1rem, 1.6vw, 1.12rem);
+  line-height: 1.8;
+}
+.bio-prose .bio-problem {
+  color: #b4373d;
+}
+.bio-prose .bio-solution {
+  color: #268744;
+}
+.bio-state {
+  padding: clamp(3rem, 9vw, 8rem);
+  border: 1px solid var(--line);
+  text-align: center;
+  background: var(--sky);
+}
+.bio-state h1 {
+  color: var(--navy);
+}
+.bio-state-error {
+  border-color: #ba5b5b;
+  background: #fff3f3;
+}
 .software-page {
   display: grid;
   gap: clamp(2rem, 5vw, 4rem);
@@ -552,6 +677,18 @@ a {
   }
   .nav-link {
     padding: 0.5rem;
+  }
+  .bio-cover {
+    min-height: 32rem;
+    background-size:
+      auto,
+      12rem 12rem,
+      15rem 15rem;
+  }
+  .bio-facts {
+    align-items: center;
+    flex-direction: column;
+    gap: 1.25rem;
   }
   .software-grid {
     grid-template-columns: 1fr;

--- a/scripts/serve-e2e.mjs
+++ b/scripts/serve-e2e.mjs
@@ -5,7 +5,16 @@ import { extname, join, normalize } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const root = fileURLToPath(new URL("../dist/apps/shell", import.meta.url));
-const base = "/nick-derobertis-site";
+const base = process.env.SITE_E2E_BASE_PATH;
+if (typeof base !== "string" || !/^\/[a-z0-9-]+$/.test(base))
+  throw new Error(
+    "SITE_E2E_BASE_PATH must start with / and contain only lowercase letters, digits, and hyphens; run the server through the Playwright config or set SITE_E2E_BASE_PATH and retry",
+  );
+const port = Number.parseInt(process.env.SITE_E2E_PORT ?? "4200", 10);
+if (!Number.isSafeInteger(port) || port < 1024 || port > 65_535)
+  throw new Error(
+    "SITE_E2E_PORT must be an integer between 1024 and 65535; set SITE_E2E_PORT to an available port in that range and retry",
+  );
 const types = {
   ".css": "text/css",
   ".html": "text/html",
@@ -31,4 +40,4 @@ createServer(async (request, response) => {
     types[extname(file)] ?? "application/octet-stream",
   );
   createReadStream(file).pipe(response);
-}).listen(4200, "127.0.0.1");
+}).listen(port, "127.0.0.1");


### PR DESCRIPTION
## Summary
- implement the responsive BIO story remote with CV-backed highlights and complete prose
- preserve the legacy /story to /bio redirect
- add standalone and host-composed browser coverage for content, responsive layout, and loading/empty/error states
- isolate Playwright servers per worktree and make the real boundary lint probe reliable under load

## Verification
- NX_BASE=origin/master NX_HEAD=HEAD just check
- just lint-llm-validate
- just lint-llm-diff (38 rules: 12 passed, 0 failed, 17 skipped, 9 not relevant)

The repository-wide just lint-llm additionally reports pre-existing findings outside this BIO change in Research state coverage, CI credential handling, generated declarations, and setup-script output.