### PR TITLE
docs: architecture, e2e journey inventory, and README closeout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@
 - Excluded: bun, because it is incompatible with the supported workspace path for Nx's rspack Module Federation executor; pnpm's workspace linker is required here. Also excluded: release automation, because GitHub Pages deployment is the artifact lifecycle; server/auth guidance, because this is a public static site with no privileged actions.
 - Coverage is 95% for library code. Shell markup is principally verified through real-browser e2e journeys.
 
-Use pnpm; never add backend or runtime API infrastructure. The shell owns routing and layout; feature remotes will compose at route boundaries. Libraries flow `shared -> layout -> shell`, enforced by Nx tags.
+Use pnpm; never add backend or runtime API infrastructure. The shell owns routing and layout. It consumes five route remotes; Home is itself a host for seven feature remotes. Remotes expose only route pages and compose only declared child remotes. Libraries flow `shared -> layout -> shell`, enforced by Nx tags. See `docs/architecture.md`.
 
 ## Workflow
 
@@ -21,14 +21,20 @@ them; `just upgrade` deliberately opts into testing latest releases.
 
 ## Journeys
 
-E2E visits all five routes at the Pages base path, verifies shared layout and route content, keyboard navigation, direct deep links, and the 404 fallback.
+This numbered inventory is the browser-test contract; extend it with every new route, feature, or state.
 
-The repository's LLM lint bar additionally requires every route and substantial
-feature scenario to cover happy, empty, loading, and error states in a real
-browser through both standalone-remote and host-composed paths. Its
-microfrontend architecture rule requires one Nx-bounded Module Federation
-remote per feature domain, exposed only at the app/routes boundary without
-cross-remote internal access or unrelated domains sharing a remote.
+1. Site shell: all five Pages-base routes load directly with header, footer, route content, and no failed assets; keyboard navigation works; each route retains useful substantive prerendered HTML without JavaScript; unknown paths show the static 404 recovery document and client-side redirect home; `/story` redirects to `/bio`.
+2. Federation ownership: all 12 remotes render without failed assets through both standalone and host-composed boundaries.
+3. Home: its composed page and carousel, cards, story, contact, timeline, skills, and awards panes cover happy, empty, loading, and error states in both render paths; action links, automatic and keyboard carousel controls, responsive breakpoints, and invalid build-script inputs are covered.
+4. Bio: complete story, responsive layout, and happy, empty, loading, and error states in both render paths.
+5. Research: category groupings, optional coauthors/resources, narrow and standard layouts, async recovery, and happy, empty, loading, and error states in both render paths.
+6. Software: project totals, optional fields, responsive grids, and happy, empty, loading, and error states in both render paths.
+7. Courses: course topics, full and sparse records, responsive panes, and happy, empty, loading, and error states in both render paths.
+8. Timeline: complete CV history; education, employment, and no-result filters; compact mobile labels; invalid-state recovery; shared styles; and happy, empty, loading, and error states in both render paths.
+9. Skills: recursive tree, pointer and keyboard stats, category drill-down, accessible selectors, responsive layouts, invalid-state recovery, shared styles, and happy, empty, loading, and error states in both render paths.
+10. Awards: selected and complete sets, optional card content, statistics, responsive layouts, async recovery, and happy, empty, loading, and error states in both render paths.
+
+Substantial scenarios must remain real-browser covered through standalone and host-composed paths. Keep one Nx-bounded remote per feature domain, exposed only at the route boundary; no cross-remote internals or mixed domains.
 
 ## Commits, releases, and merging
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,63 @@
 # Nick DeRobertis site
 
-Static Nx + React shell for the GitHub Pages project URL at `https://nickderobertis.github.io/nick-derobertis-site/`. The custom domain remains served by the legacy AWS deployment until a separate migration.
+Nick DeRobertis's static professional site, built as an Nx monorepo with React,
+rspack, and Module Federation. It is published at
+<https://nickderobertis.github.io/nick-derobertis-site/>. The custom domain
+continues to use the legacy AWS deployment until it is migrated separately.
 
-Run `just bootstrap`, then `just check`.
+## Local development
+
+Install Node 26 and [`just`](https://just.systems/), then bootstrap the pinned
+pnpm workspace:
+
+```bash
+just bootstrap
+```
+
+Run the complete shell and federated graph through the supported local browser
+harness:
+
+```bash
+just test-e2e
+```
+
+It builds and prerenders the artifact, starts the static server, and exercises
+the real site. Routes live below the project base `/nick-derobertis-site/`;
+each remote is also exercised below `/nick-derobertis-site/remotes/<remote>/`
+for standalone development and tests. Use `just e2e-project <remote>` for a
+focused iteration loop.
+
+## Test and build
+
+`just check` is the complete pre-push gate. It formats-checks the workspace,
+lints workflows and shell scripts, and runs affected lint, typecheck, unit,
+build, prerender, browser, and visual targets plus the complete shell browser
+integration suite.
+
+```bash
+just check
+```
+
+Useful focused commands are:
+
+```bash
+just test                 # affected unit and browser tests
+just test-e2e             # complete shell browser journeys
+just e2e-project skills   # one remote, standalone and host-composed
+just prerender            # static artifact in dist/apps/shell
+just lint                 # all-project lint and typecheck
+just format               # apply Biome formatting
+```
+
+Set `NX_BASE` and `NX_HEAD` to override the affected range used by `just check`
+and `just test`. CI runs `just check-all` on `master` as a non-affected safety
+sweep. See [the architecture](docs/architecture.md) for project boundaries,
+hosting, and affected-test behavior.
+
+## Deploy
+
+Pushes to `master` run the full CI gate and the `pages.yml` workflow. That
+workflow installs the locked dependencies, runs `shell:prerender`, uploads
+`dist/apps/shell`, and deploys it with GitHub Pages. `workflow_dispatch` can
+rerun the same deployment manually. There is no runtime server or API to
+provision.

--- a/README.md
+++ b/README.md
@@ -14,18 +14,17 @@ pnpm workspace:
 just bootstrap
 ```
 
-Run the complete shell and federated graph through the supported local browser
-harness:
+Start the complete shell and federated graph for interactive development:
 
 ```bash
-just test-e2e
+just serve
 ```
 
-It builds and prerenders the artifact, starts the static server, and exercises
-the real site. Routes live below the project base `/nick-derobertis-site/`;
-each remote is also exercised below `/nick-derobertis-site/remotes/<remote>/`
-for standalone development and tests. Use `just e2e-project <remote>` for a
-focused iteration loop.
+Open <http://127.0.0.1:4200/nick-derobertis-site/>. The recipe rebuilds and
+prerenders the complete static artifact before serving it, so restart it after
+source changes. Press Ctrl-C in its terminal to stop the server. Standalone
+remotes are available at
+`http://127.0.0.1:4200/nick-derobertis-site/remotes/<remote>/`.
 
 ## Test and build
 
@@ -45,6 +44,7 @@ just test                 # affected unit and browser tests
 just test-e2e             # complete shell browser journeys
 just e2e-project skills   # one remote, standalone and host-composed
 just prerender            # static artifact in dist/apps/shell
+just serve                # interactive static development server
 just lint                 # all-project lint and typecheck
 just format               # apply Biome formatting
 ```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,69 @@
+# Architecture
+
+## Omnidirectional federation
+
+The site is a static graph of independently built React applications. The
+shell owns the Pages base path, shared layout, and browser routes. It consumes
+the `home`, `bio`, `research`, `software`, and `courses` route remotes. The
+`home` remote is also a host: it composes `home-carousel`, `home-cards`,
+`home-story`, `home-contact`, `timeline`, `skills`, and `awards`. Every remote
+exposes only `./Page`; the shell additionally exposes `./App`. This makes a
+feature testable either inside its parent host or directly at its standalone
+URL while preserving route-boundary ownership.
+
+`libs/build-config/src/remotes.json` is the canonical remote registry.
+`remoteMap` turns it into project-base URLs, and the prerender target uses the
+same registry when staging every `remoteEntry.js`. React and React DOM are
+singleton federation dependencies. Nx project tags and ESLint prevent feature
+domains from reaching into one another: shared libraries may use only shared
+libraries, layout may use shared libraries, the shell may use layout and
+shared libraries, and remotes may consume shared libraries or explicitly
+allowed child remotes.
+
+The shared-library direction is:
+
+```text
+shared libraries -> layout -> shell
+        |
+        +---------> feature remotes -> declared child remotes
+```
+
+`data-access` owns schema validation and data shaping, `design-system` owns the
+visual foundation, `ui` owns reusable components, `analytics` owns browser
+analytics, and `build-config` owns federation build configuration. Feature data
+hooks may read the staged same-origin JSON, but they validate it through
+`data-access` before rendering.
+
+## Static hosting and data
+
+The former API is intentionally gone: there is no backend or runtime API. CV data is generated outside this
+repository, committed under `libs/data-access/vendor/codegen`, and validated at
+the data-access and prerender boundaries. Prerender copies the validated files
+to `cv-data/` in the artifact; browser data requests therefore remain static
+same-origin file reads.
+
+`shell:prerender` builds a GitHub Pages artifact at `dist/apps/shell` under the
+`/nick-derobertis-site/` base. It emits HTML for all five routes, stages every
+remote below `remotes/<name>/`, copies CV data, and creates `404.html`. The
+fallback supplies useful no-script recovery text; with JavaScript enabled the
+client router restores an unknown deep link to the home route. GitHub Actions
+uploads this directory directly to Pages. The custom domain is intentionally
+outside this deployment until its separate migration.
+
+## Affected-only economics
+
+Pull-request gates use Nx's dependency graph between `NX_BASE` and `NX_HEAD`.
+They run expensive build, prerender, e2e, and screenshot work only where a
+change can have an effect, while always running the shell-wide integration
+suite. Pushes to `master` add `check-all`, so affected selection is an
+optimization rather than the only safety net.
+
+The measured integration review is recorded in
+[integration-proof.md](integration-proof.md). Its `nx affected --files` proof
+showed that a design-system change selected all 12 dependent remotes, a Skills
+page change selected only `skills:e2e`, and a data-access change selected the
+10 consumers while excluding `home` and `bio`. In the Skills case, 25 browser
+tests passed and only one e2e target ran; the remaining 14 tasks were required
+static build/prerender dependencies. The shell integration target separately
+protects navigation, direct routes, static markup, fallback recovery, and the
+cross-remote state matrix.

--- a/justfile
+++ b/justfile
@@ -64,6 +64,10 @@ test-e2e:
 prerender:
     log=$(mktemp); trap 'rm -f "$log"' EXIT; pnpm exec nx run shell:prerender >"$log" 2>&1 || { cat "$log" >&2; echo "prerender: static Pages artifact failed; fix the build or artifact validation above and rerun just prerender" >&2; exit 1; }
 
+# Build the complete federated artifact before serving it at the Pages base path.
+serve: prerender
+    node scripts/serve-e2e.mjs
+
 e2e-affected-files file:
     # llmlint: ignore[tool_output_is_signal] This proof command intentionally preserves unedited Nx selection and execution output for docs/integration-proof.md.
     file="$1"; [[ "$file" != /* && "$file" != *..* && -f "$file" ]] || { echo "e2e-affected-files: file must be a tracked workspace-relative file" >&2; exit 2; }; pnpm exec nx show projects --affected --files="$file" --with-target=e2e --json && pnpm exec nx affected -t e2e --files="$file" --parallel=3


### PR DESCRIPTION
## What
Closeout docs for the rewritten site: AGENTS.md stack-and-composition + enumerated e2e journey inventory, a docs/architecture.md covering the omnidirectional Module-Federation design, shared-lib boundaries, GitHub Pages static/prerender/404 hosting, the killed-API/build-time-data model, and the affected-only test economics; README refresh; and a just recipe to run the site interactively.

## Why
Durable documentation of the new architecture and the growing e2e journey contract.

## Additional info
The node's local `just check` failed only on a flaky e2e web-server port conflict (127.0.0.1:4301 already in use by a concurrent run) — an infra flake, not a docs/code issue. Docs-only changes do not affect e2e behavior.