### PR TITLE
fix(llmlint): cap judge batch_size to prevent JSON overflow

### DIFF
--- a/llmlint.yml
+++ b/llmlint.yml
@@ -24,6 +24,13 @@ plugins:
   - "https://raw.githubusercontent.com/nickderobertis/dero-skills/main/skills/bootstrap/create-repo/assets/llmlint/languages/typescript.llmlint.yml@1"
   - "https://raw.githubusercontent.com/nickderobertis/dero-skills/main/skills/bootstrap/create-repo/assets/llmlint/ci.llmlint.yml@1"
   - "https://raw.githubusercontent.com/nickderobertis/dero-skills/main/skills/bootstrap/create-repo/assets/llmlint/monorepo.llmlint.yml@1"
+agents:
+  # Cap rules per judge run: the default (20) packed every diff-wide rule into
+  # one call whose combined verdict+rationale output overran the judge and
+  # returned no parseable JSON on large changesets. Smaller batches keep each
+  # call's output within budget. Harness/model left unset to preserve oneharness fallback.
+  default:
+    batch_size: 5
 rules:
   - name: changed_behavior_has_e2e
     override: true


### PR DESCRIPTION
## What
Add an `agents` block to `llmlint.yml` that caps the default judge agent's `batch_size` at 5 (down from the built-in default of 20). Insert it immediately before the top-level `rules:` key:

```yaml
agents:
  # Cap rules per judge run: the default (20) packed every diff-wide rule into
  # one call whose combined verdict+rationale output overran the judge and
  # returned no parseable JSON on large changesets. Smaller batches keep each
  # call's output within budget. Harness/model left unset to preserve oneharness fallback.
  default:
    batch_size: 5
```

Do NOT set `harness` or `model` (leave them unset so the oneharness fallback still selects them). Change nothing else.

## Why
llmlint's default `batch_size: 20` groups every applicable rule into a single judge call; with `rationales: true`, the model must emit a verdict AND rationale for ~20 rules in one response. On a wide changeset that combined output overruns the judge and llmlint reports `no JSON value could be extracted from the response`, erroring `lint-llm-diff` (exit 2) with ZERO real findings. This deterministically blocks every large change in this repo (it stalled the data-lib split across multiple full retries). Smaller batches keep each call's output within budget so the judge returns parseable JSON. Verified: with batch_size 5 the same diff that errored now completes and the judge emits real verdicts.
