### PR TITLE
perf(nx): centralize local cache outside worktrees

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,15 @@ Dependency freshness is checked with `pnpm outdated`; every dependency's
 updates remain outside those constraints until their Nx integrations support
 them; `just upgrade` deliberately opts into testing latest releases.
 
+The `justfile` defaults `NX_CACHE_DIRECTORY` to the repo-scoped
+`$XDG_CACHE_HOME/nx/nick-derobertis-site` (or
+`$HOME/.cache/nx/nick-derobertis-site`) so disposable worktrees reuse Nx's
+content-addressed local cache. An existing `NX_CACHE_DIRECTORY` overrides the
+default. Use this shared local cache only when Nx dispatch concurrency is 1:
+parallel Nx processes sharing its cache database can encounter SQLite lock or
+foreign-key contention. Higher-concurrency dispatches require Nx's supported
+cache locking or a remote cache.
+
 ## Journeys
 
 This numbered inventory is the browser-test contract; extend it with every new route, feature, or state.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,11 +19,11 @@ Dependency freshness is checked with `pnpm outdated`; every dependency's
 updates remain outside those constraints until their Nx integrations support
 them; `just upgrade` deliberately opts into testing latest releases.
 
-The `justfile` defaults `NX_CACHE_DIRECTORY` to the repo-scoped
-`$XDG_CACHE_HOME/nx/nick-derobertis-site` (or
-`$HOME/.cache/nx/nick-derobertis-site`) so disposable worktrees reuse Nx's
-content-addressed local cache. An existing `NX_CACHE_DIRECTORY` overrides the
-default. Use this shared local cache only when Nx dispatch concurrency is 1:
+The `justfile` is the authoritative source for the repo-scoped
+`NX_CACHE_DIRECTORY` default beneath the user's standard cache directory, so
+disposable worktrees reuse Nx's content-addressed local cache. An existing
+`NX_CACHE_DIRECTORY` overrides the default. Use this shared local cache only
+when Nx dispatch concurrency is 1:
 parallel Nx processes sharing its cache database can encounter SQLite lock or
 foreign-key contention. Higher-concurrency dispatches require Nx's supported
 cache locking or a remote cache.

--- a/justfile
+++ b/justfile
@@ -1,6 +1,10 @@
 set shell := ["bash", "-euo", "pipefail", "-c"]
 set positional-arguments := true
 
+# Keep Nx's content-addressed cache across disposable git worktrees. Callers can
+# override this when they need an isolated cache.
+export NX_CACHE_DIRECTORY := env_var_or_default("NX_CACHE_DIRECTORY", env_var_or_default("XDG_CACHE_HOME", env_var("HOME") + "/.cache") + "/nx/nick-derobertis-site")
+
 # Bun is explicitly ruled out: Nx's rspack Module Federation executor supports
 # this workspace through pnpm's linker. pnpm is the documented fallback in
 # AGENTS.md and the composed Stack-and-composition record.

--- a/justfile
+++ b/justfile
@@ -3,6 +3,7 @@ set positional-arguments := true
 
 # Keep Nx's content-addressed cache across disposable git worktrees. Callers can
 # override this when they need an isolated cache.
+# llmlint: ignore[boundary_inputs_validated] just passes this path as one environment value to Nx; it is never interpolated into a shell command, and Nx owns directory-path validation.
 export NX_CACHE_DIRECTORY := env_var_or_default("NX_CACHE_DIRECTORY", env_var_or_default("XDG_CACHE_HOME", env_var("HOME") + "/.cache") + "/nx/nick-derobertis-site")
 
 # Bun is explicitly ruled out: Nx's rspack Module Federation executor supports


### PR DESCRIPTION
## What
Make nx's local cache live in a stable directory OUTSIDE the per-dispatch git worktree, via `NX_CACHE_DIRECTORY`, so cache entries persist and are reused across worktrees, retries, and the orchestrator's verification gate instead of being discarded on worktree teardown.

- Set a DEFAULT `NX_CACHE_DIRECTORY` to a stable, host-local, repo-scoped path that resolves to the SAME absolute location for every worktree of this repo (e.g. under `$HOME/.cache`), and is overridable by an existing env value. The simplest correct place is a top-level `just` export so the registered gate (`just check`) and any direct nx runs all inherit it. Do NOT commit a machine-specific absolute path — derive it (e.g. from the home directory) or make it env-overridable.
- It must NOT point inside the worktree (that is the current behavior that breaks reuse) and must be identical across worktrees so they share one content-hash-keyed cache.
- Keep `.nx/` gitignored (unchanged).
- PROVE the win empirically: run the gate once from a cold shared cache (populates it), then simulate a second fresh worktree (or delete the in-tree `.nx` and re-run) and show the second run gets a high nx cache-hit rate from the shared dir — cite the `Cache: X/Y hit (N%)` lines before and after. Confirm nx hashes are stable across different worktree paths (if they are not, adjust so cross-worktree hits actually occur).
- Document the choice and the concurrency caveat in AGENTS.md (or a linked docs note): a shared nx cache/DB under PARALLEL nx runs can hit SQLite lock / FOREIGN KEY contention (observed in this project), so it is safe at concurrency 1; for higher concurrency use nx's proper cache locking or a remote cache.

## Why
Every lifecycle dispatch runs in a fresh git worktree, and nx caches to the gitignored `.nx/` INSIDE that worktree, so the cache is thrown away on teardown and never shared across worktrees, retries, or the verification gate. The expensive `nx affected` suite (typecheck/test/build/prerender/e2e/screenshot, ~16 min) therefore runs cold on essentially every attempt and dominates each node's wall time. Centralizing the cache in a stable shared directory lets a fresh worktree on the same commits hit the cache and skip recomputation, cutting node latency substantially.
