### PR TITLE
feat(skeletons): per-remote loading skeletons, eager fallback

### DIFF
--- a/apps/awards/src/main.tsx
+++ b/apps/awards/src/main.tsx
@@ -1,7 +1,14 @@
 import "@site/design-system";
+import { lazy, Suspense } from "react";
 import { createRoot } from "react-dom/client";
-import Page from "./page";
+import Skeleton from "./skeleton";
+
+const Page = lazy(() => import("./page"));
 
 const root = document.getElementById("root");
 if (!root) throw new Error("Missing remote root");
-createRoot(root).render(<Page />);
+createRoot(root).render(
+  <Suspense fallback={<Skeleton />}>
+    <Page />
+  </Suspense>,
+);

--- a/apps/awards/src/skeleton.tsx
+++ b/apps/awards/src/skeleton.tsx
@@ -1,0 +1,15 @@
+export default function AwardsSkeleton() {
+  return (
+    <section
+      className="remote-skeleton skeleton-awards"
+      role="status"
+      aria-label="Loading awards"
+    >
+      <div className="skeleton-grid">
+        {[1, 2, 3].map((item) => (
+          <i key={item} />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/bio/src/main.tsx
+++ b/apps/bio/src/main.tsx
@@ -1,6 +1,14 @@
+import "@site/design-system";
+import { lazy, Suspense } from "react";
 import { createRoot } from "react-dom/client";
-import Page from "./page";
+import Skeleton from "./skeleton";
+
+const Page = lazy(() => import("./page"));
 
 const root = document.getElementById("root");
 if (!root) throw new Error("Missing remote root");
-createRoot(root).render(<Page />);
+createRoot(root).render(
+  <Suspense fallback={<Skeleton />}>
+    <Page />
+  </Suspense>,
+);

--- a/apps/bio/src/skeleton.tsx
+++ b/apps/bio/src/skeleton.tsx
@@ -1,0 +1,18 @@
+export default function BioSkeleton() {
+  return (
+    <article
+      className="remote-skeleton skeleton-bio"
+      role="status"
+      aria-label="Loading biography"
+    >
+      <div className="skeleton-cover" />
+      <div className="skeleton-copy">
+        <b />
+        <i />
+        <i />
+        <i />
+        <i />
+      </div>
+    </article>
+  );
+}

--- a/apps/courses/src/main.tsx
+++ b/apps/courses/src/main.tsx
@@ -1,6 +1,14 @@
+import "@site/design-system";
+import { lazy, Suspense } from "react";
 import { createRoot } from "react-dom/client";
-import Page from "./page";
+import Skeleton from "./skeleton";
+
+const Page = lazy(() => import("./page"));
 
 const root = document.getElementById("root");
 if (!root) throw new Error("Missing remote root");
-createRoot(root).render(<Page />);
+createRoot(root).render(
+  <Suspense fallback={<Skeleton />}>
+    <Page />
+  </Suspense>,
+);

--- a/apps/courses/src/skeleton.tsx
+++ b/apps/courses/src/skeleton.tsx
@@ -1,0 +1,13 @@
+export default function CoursesSkeleton() {
+  return (
+    <section
+      className="remote-skeleton skeleton-courses"
+      role="status"
+      aria-label="Loading courses"
+    >
+      <div className="skeleton-banner" />
+      <div className="skeleton-course" />
+      <div className="skeleton-course" />
+    </section>
+  );
+}

--- a/apps/home-cards/src/main.tsx
+++ b/apps/home-cards/src/main.tsx
@@ -1,7 +1,14 @@
 import "@site/design-system";
+import { lazy, Suspense } from "react";
 import { createRoot } from "react-dom/client";
-import Page from "./page";
+import Skeleton from "./skeleton";
+
+const Page = lazy(() => import("./page"));
 
 const root = document.getElementById("root");
 if (!root) throw new Error("Missing remote root");
-createRoot(root).render(<Page />);
+createRoot(root).render(
+  <Suspense fallback={<Skeleton />}>
+    <Page />
+  </Suspense>,
+);

--- a/apps/home-cards/src/skeleton.tsx
+++ b/apps/home-cards/src/skeleton.tsx
@@ -1,0 +1,15 @@
+export default function HomeCardsSkeleton() {
+  return (
+    <section
+      className="remote-skeleton skeleton-cards"
+      role="status"
+      aria-label="Loading areas of work"
+    >
+      <div className="skeleton-grid">
+        {[1, 2, 3].map((item) => (
+          <i key={item} />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/home-carousel/src/main.tsx
+++ b/apps/home-carousel/src/main.tsx
@@ -1,7 +1,14 @@
 import "@site/design-system";
+import { lazy, Suspense } from "react";
 import { createRoot } from "react-dom/client";
-import Page from "./page";
+import Skeleton from "./skeleton";
+
+const Page = lazy(() => import("./page"));
 
 const root = document.getElementById("root");
 if (!root) throw new Error("Missing remote root");
-createRoot(root).render(<Page />);
+createRoot(root).render(
+  <Suspense fallback={<Skeleton />}>
+    <Page />
+  </Suspense>,
+);

--- a/apps/home-carousel/src/skeleton.tsx
+++ b/apps/home-carousel/src/skeleton.tsx
@@ -1,0 +1,12 @@
+export default function HomeCarouselSkeleton() {
+  return (
+    <section
+      className="remote-skeleton skeleton-carousel"
+      role="status"
+      aria-label="Loading featured work"
+    >
+      <div className="skeleton-hero" />
+      <div className="skeleton-dots" />
+    </section>
+  );
+}

--- a/apps/home-contact/src/main.tsx
+++ b/apps/home-contact/src/main.tsx
@@ -1,7 +1,14 @@
 import "@site/design-system";
+import { lazy, Suspense } from "react";
 import { createRoot } from "react-dom/client";
-import Page from "./page";
+import Skeleton from "./skeleton";
+
+const Page = lazy(() => import("./page"));
 
 const root = document.getElementById("root");
 if (!root) throw new Error("Missing remote root");
-createRoot(root).render(<Page />);
+createRoot(root).render(
+  <Suspense fallback={<Skeleton />}>
+    <Page />
+  </Suspense>,
+);

--- a/apps/home-contact/src/skeleton.tsx
+++ b/apps/home-contact/src/skeleton.tsx
@@ -1,0 +1,20 @@
+export default function HomeContactSkeleton() {
+  return (
+    <section
+      className="remote-skeleton skeleton-contact"
+      role="status"
+      aria-label="Loading contact options"
+    >
+      <div className="skeleton-copy">
+        <b />
+        <i />
+        <i />
+      </div>
+      <div className="skeleton-links">
+        <i />
+        <i />
+        <i />
+      </div>
+    </section>
+  );
+}

--- a/apps/home-story/src/main.tsx
+++ b/apps/home-story/src/main.tsx
@@ -1,7 +1,14 @@
 import "@site/design-system";
+import { lazy, Suspense } from "react";
 import { createRoot } from "react-dom/client";
-import Page from "./page";
+import Skeleton from "./skeleton";
+
+const Page = lazy(() => import("./page"));
 
 const root = document.getElementById("root");
 if (!root) throw new Error("Missing remote root");
-createRoot(root).render(<Page />);
+createRoot(root).render(
+  <Suspense fallback={<Skeleton />}>
+    <Page />
+  </Suspense>,
+);

--- a/apps/home-story/src/skeleton.tsx
+++ b/apps/home-story/src/skeleton.tsx
@@ -1,0 +1,17 @@
+export default function HomeStorySkeleton() {
+  return (
+    <section
+      className="remote-skeleton skeleton-story"
+      role="status"
+      aria-label="Loading story"
+    >
+      <div className="skeleton-portrait" />
+      <div className="skeleton-copy">
+        <b />
+        <i />
+        <i />
+        <i />
+      </div>
+    </section>
+  );
+}

--- a/apps/home/src/main.tsx
+++ b/apps/home/src/main.tsx
@@ -1,7 +1,14 @@
 import "@site/design-system";
+import { lazy, Suspense } from "react";
 import { createRoot } from "react-dom/client";
-import Page from "./page";
+import Skeleton from "./skeleton";
+
+const Page = lazy(() => import("./page"));
 
 const root = document.getElementById("root");
 if (!root) throw new Error("Missing remote root");
-createRoot(root).render(<Page />);
+createRoot(root).render(
+  <Suspense fallback={<Skeleton />}>
+    <Page />
+  </Suspense>,
+);

--- a/apps/home/src/page.tsx
+++ b/apps/home/src/page.tsx
@@ -1,7 +1,16 @@
+import CardsSkeleton from "homeCards/Skeleton";
+import CarouselSkeleton from "homeCarousel/Skeleton";
+import ContactSkeleton from "homeContact/Skeleton";
+import StorySkeleton from "homeStory/Skeleton";
 import { siteBase } from "@site/data-access-core";
 import { homeContent } from "@site/data-access-home";
+import AwardsSkeleton from "awards/Skeleton";
 import { lazy, Suspense } from "react";
+import SkillsSkeleton from "skills/Skeleton";
+import TimelineSkeleton from "timeline/Skeleton";
 
+// Home eagerly resolves each pane's lightweight skeleton while its Page stays
+// behind a dynamic import, preserving an app-shaped fallback per pane.
 const Carousel = lazy(() => import("homeCarousel/Page"));
 const Cards = lazy(() => import("homeCards/Page"));
 const Story = lazy(() => import("homeStory/Page"));
@@ -17,15 +26,25 @@ void homeContent;
 export default function HomePage() {
   return (
     <div className="home-main">
-      <Suspense
-        fallback={<output className="pane-state">Loading HOME page…</output>}
-      >
+      <Suspense fallback={<CarouselSkeleton />}>
         <Carousel />
+      </Suspense>
+      <Suspense fallback={<CardsSkeleton />}>
         <Cards />
+      </Suspense>
+      <Suspense fallback={<StorySkeleton />}>
         <Story />
+      </Suspense>
+      <Suspense fallback={<SkillsSkeleton />}>
         <Skills />
+      </Suspense>
+      <Suspense fallback={<AwardsSkeleton />}>
         <Awards />
+      </Suspense>
+      <Suspense fallback={<ContactSkeleton />}>
         <Contact />
+      </Suspense>
+      <Suspense fallback={<TimelineSkeleton />}>
         <Timeline />
       </Suspense>
     </div>

--- a/apps/home/src/remotes.d.ts
+++ b/apps/home/src/remotes.d.ts
@@ -42,3 +42,46 @@ declare module "awards/Page" {
   const Page: ComponentType;
   export default Page;
 }
+
+declare module "homeCarousel/Skeleton" {
+  import type { ComponentType } from "react";
+
+  const Skeleton: ComponentType;
+  export default Skeleton;
+}
+declare module "homeCards/Skeleton" {
+  import type { ComponentType } from "react";
+
+  const Skeleton: ComponentType;
+  export default Skeleton;
+}
+declare module "homeStory/Skeleton" {
+  import type { ComponentType } from "react";
+
+  const Skeleton: ComponentType;
+  export default Skeleton;
+}
+declare module "homeContact/Skeleton" {
+  import type { ComponentType } from "react";
+
+  const Skeleton: ComponentType;
+  export default Skeleton;
+}
+declare module "timeline/Skeleton" {
+  import type { ComponentType } from "react";
+
+  const Skeleton: ComponentType;
+  export default Skeleton;
+}
+declare module "skills/Skeleton" {
+  import type { ComponentType } from "react";
+
+  const Skeleton: ComponentType;
+  export default Skeleton;
+}
+declare module "awards/Skeleton" {
+  import type { ComponentType } from "react";
+
+  const Skeleton: ComponentType;
+  export default Skeleton;
+}

--- a/apps/home/src/remotes.d.ts
+++ b/apps/home/src/remotes.d.ts
@@ -1,3 +1,5 @@
+/// <reference path="../../../libs/build-config/src/federation-modules.d.ts" />
+
 declare module "homeCarousel/Page" {
   import type { ComponentType } from "react";
 
@@ -41,47 +43,4 @@ declare module "awards/Page" {
 
   const Page: ComponentType;
   export default Page;
-}
-
-declare module "homeCarousel/Skeleton" {
-  import type { ComponentType } from "react";
-
-  const Skeleton: ComponentType;
-  export default Skeleton;
-}
-declare module "homeCards/Skeleton" {
-  import type { ComponentType } from "react";
-
-  const Skeleton: ComponentType;
-  export default Skeleton;
-}
-declare module "homeStory/Skeleton" {
-  import type { ComponentType } from "react";
-
-  const Skeleton: ComponentType;
-  export default Skeleton;
-}
-declare module "homeContact/Skeleton" {
-  import type { ComponentType } from "react";
-
-  const Skeleton: ComponentType;
-  export default Skeleton;
-}
-declare module "timeline/Skeleton" {
-  import type { ComponentType } from "react";
-
-  const Skeleton: ComponentType;
-  export default Skeleton;
-}
-declare module "skills/Skeleton" {
-  import type { ComponentType } from "react";
-
-  const Skeleton: ComponentType;
-  export default Skeleton;
-}
-declare module "awards/Skeleton" {
-  import type { ComponentType } from "react";
-
-  const Skeleton: ComponentType;
-  export default Skeleton;
 }

--- a/apps/home/src/skeleton.tsx
+++ b/apps/home/src/skeleton.tsx
@@ -1,0 +1,16 @@
+export default function HomeSkeleton() {
+  return (
+    <section
+      className="remote-skeleton skeleton-home"
+      role="status"
+      aria-label="Loading home"
+    >
+      <div className="skeleton-hero" />
+      <div className="skeleton-grid">
+        {[1, 2, 3].map((item) => (
+          <i key={item} />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/research/src/main.tsx
+++ b/apps/research/src/main.tsx
@@ -1,6 +1,14 @@
+import "@site/design-system";
+import { lazy, Suspense } from "react";
 import { createRoot } from "react-dom/client";
-import Page from "./page";
+import Skeleton from "./skeleton";
+
+const Page = lazy(() => import("./page"));
 
 const root = document.getElementById("root");
 if (!root) throw new Error("Missing remote root");
-createRoot(root).render(<Page />);
+createRoot(root).render(
+  <Suspense fallback={<Skeleton />}>
+    <Page />
+  </Suspense>,
+);

--- a/apps/research/src/skeleton.tsx
+++ b/apps/research/src/skeleton.tsx
@@ -1,0 +1,16 @@
+export default function ResearchSkeleton() {
+  return (
+    <section
+      className="remote-skeleton skeleton-research"
+      role="status"
+      aria-label="Loading research"
+    >
+      <div className="skeleton-heading" />
+      <div className="skeleton-list">
+        {[1, 2, 3].map((item) => (
+          <i key={item} />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/shell-e2e/playwright.config.ts
+++ b/apps/shell-e2e/playwright.config.ts
@@ -27,7 +27,7 @@ export default defineConfig({
     trace: "retain-on-failure",
   },
   webServer: {
-    command: `PORT=${port} STATIC_ASSET_LATENCY_MS=500 node ../../scripts/serve-e2e.mjs`,
+    command: `PORT=${port} JAVASCRIPT_ASSET_LATENCY_MS=300 node ../../scripts/serve-e2e.mjs`,
     url: testBaseUrl,
     reuseExistingServer: !process.env.CI,
   },

--- a/apps/shell-e2e/playwright.config.ts
+++ b/apps/shell-e2e/playwright.config.ts
@@ -27,7 +27,7 @@ export default defineConfig({
     trace: "retain-on-failure",
   },
   webServer: {
-    command: `PORT=${port} JAVASCRIPT_ASSET_LATENCY_MS=300 node ../../scripts/serve-e2e.mjs`,
+    command: `PORT=${port} node ../../scripts/serve-e2e.mjs`,
     url: testBaseUrl,
     reuseExistingServer: !process.env.CI,
   },

--- a/apps/shell-e2e/playwright.config.ts
+++ b/apps/shell-e2e/playwright.config.ts
@@ -27,7 +27,7 @@ export default defineConfig({
     trace: "retain-on-failure",
   },
   webServer: {
-    command: `PORT=${port} node ../../scripts/serve-e2e.mjs`,
+    command: `PORT=${port} STATIC_ASSET_LATENCY_MS=500 node ../../scripts/serve-e2e.mjs`,
     url: testBaseUrl,
     reuseExistingServer: !process.env.CI,
   },

--- a/apps/shell-e2e/src/awards.spec.ts
+++ b/apps/shell-e2e/src/awards.spec.ts
@@ -94,7 +94,9 @@ for (const renderPath of renderPaths) {
       page,
     }) => {
       await page.goto(`${renderPath.path}?awards-scenario=loading`);
-      const loading = page.getByRole("status");
+      const loading = page
+        .getByRole("status")
+        .filter({ hasText: "Loading awards…" });
       await expect(loading).toContainText("Loading awards…");
       await expect(
         page.getByRole("heading", { name: "Selected awards" }),

--- a/apps/shell-e2e/src/home.spec.ts
+++ b/apps/shell-e2e/src/home.spec.ts
@@ -215,18 +215,6 @@ test("script entry points reject invalid inputs with recovery actions", async ()
   });
   expect(invalidPort.status).not.toBe(0);
   expect(invalidPort.stderr).toContain("run just test-e2e again");
-  const invalidLatency = spawnSync(
-    process.execPath,
-    ["scripts/serve-e2e.mjs"],
-    {
-      env: { ...process.env, JAVASCRIPT_ASSET_LATENCY_MS: "invalid" },
-      encoding: "utf8",
-    },
-  );
-  expect(invalidLatency.status).not.toBe(0);
-  expect(invalidLatency.stderr).toContain(
-    "JAVASCRIPT_ASSET_LATENCY_MS must be an integer",
-  );
   const occupiedServer = createServer();
   await new Promise<void>((resolve) =>
     occupiedServer.listen(0, "127.0.0.1", resolve),

--- a/apps/shell-e2e/src/home.spec.ts
+++ b/apps/shell-e2e/src/home.spec.ts
@@ -215,6 +215,18 @@ test("script entry points reject invalid inputs with recovery actions", async ()
   });
   expect(invalidPort.status).not.toBe(0);
   expect(invalidPort.stderr).toContain("run just test-e2e again");
+  const invalidLatency = spawnSync(
+    process.execPath,
+    ["scripts/serve-e2e.mjs"],
+    {
+      env: { ...process.env, STATIC_ASSET_LATENCY_MS: "invalid" },
+      encoding: "utf8",
+    },
+  );
+  expect(invalidLatency.status).not.toBe(0);
+  expect(invalidLatency.stderr).toContain(
+    "STATIC_ASSET_LATENCY_MS must be an integer",
+  );
   const occupiedServer = createServer();
   await new Promise<void>((resolve) =>
     occupiedServer.listen(0, "127.0.0.1", resolve),
@@ -249,4 +261,14 @@ test("script entry points reject invalid inputs with recovery actions", async ()
   } finally {
     await rm(fixture, { recursive: true, force: true });
   }
+});
+
+test("static routes tolerate malformed Referer headers", async ({
+  request,
+}) => {
+  const response = await request.get("", {
+    headers: { referer: "not a valid URL" },
+  });
+  expect(response.status()).toBe(200);
+  await expect(response.text()).resolves.toContain("<html");
 });

--- a/apps/shell-e2e/src/home.spec.ts
+++ b/apps/shell-e2e/src/home.spec.ts
@@ -219,13 +219,13 @@ test("script entry points reject invalid inputs with recovery actions", async ()
     process.execPath,
     ["scripts/serve-e2e.mjs"],
     {
-      env: { ...process.env, STATIC_ASSET_LATENCY_MS: "invalid" },
+      env: { ...process.env, JAVASCRIPT_ASSET_LATENCY_MS: "invalid" },
       encoding: "utf8",
     },
   );
   expect(invalidLatency.status).not.toBe(0);
   expect(invalidLatency.stderr).toContain(
-    "STATIC_ASSET_LATENCY_MS must be an integer",
+    "JAVASCRIPT_ASSET_LATENCY_MS must be an integer",
   );
   const occupiedServer = createServer();
   await new Promise<void>((resolve) =>

--- a/apps/shell-e2e/src/remote-owner.spec.ts
+++ b/apps/shell-e2e/src/remote-owner.spec.ts
@@ -120,22 +120,19 @@ for (const [render, path] of [
     page,
   }) => {
     let pageChunkRequested = false;
-    await page.route(`**/remotes/${owner}/*.js`, async (route) => {
-      const filename = new URL(route.request().url()).pathname
-        .split("/")
-        .at(-1);
+    page.on("request", (request) => {
+      const filename = new URL(request.url()).pathname.split("/").at(-1);
+      const isOwnedRemoteChunk = request.url().includes(`/remotes/${owner}/`);
       const isPageChunk =
+        isOwnedRemoteChunk &&
         filename !== "remoteEntry.js" &&
         !filename?.startsWith("main.") &&
         !filename?.startsWith("__federation_expose_Skeleton.");
-      if (isPageChunk) {
-        pageChunkRequested = true;
-        await new Promise((resolve) => setTimeout(resolve, 1_000));
-      }
-      await route.continue();
+      if (isPageChunk) pageChunkRequested = true;
     });
 
-    await page.goto(path, { waitUntil: "domcontentloaded" });
+    const loadingPath = `${path}${path.includes("?") ? "&" : "?"}e2e-page-delay=${owner}`;
+    await page.goto(loadingPath, { waitUntil: "domcontentloaded" });
     await expect(
       page.getByRole("status", { name: contract.loadingName, exact: true }),
     ).toBeVisible();

--- a/apps/shell-e2e/src/remote-owner.spec.ts
+++ b/apps/shell-e2e/src/remote-owner.spec.ts
@@ -119,20 +119,7 @@ for (const [render, path] of [
   test(`${owner} shows its skeleton while loading through its ${render} boundary`, async ({
     page,
   }) => {
-    let pageChunkRequested = false;
-    page.on("request", (request) => {
-      const filename = new URL(request.url()).pathname.split("/").at(-1);
-      const isOwnedRemoteChunk = request.url().includes(`/remotes/${owner}/`);
-      const isPageChunk =
-        isOwnedRemoteChunk &&
-        filename !== "remoteEntry.js" &&
-        !filename?.startsWith("main.") &&
-        !filename?.startsWith("__federation_expose_Skeleton.");
-      if (isPageChunk) pageChunkRequested = true;
-    });
-
-    const loadingPath = `${path}${path.includes("?") ? "&" : "?"}e2e-page-delay=${owner}`;
-    await page.goto(loadingPath, { waitUntil: "domcontentloaded" });
+    await page.goto(path, { waitUntil: "domcontentloaded" });
     await expect(
       page.getByRole("status", { name: contract.loadingName, exact: true }),
     ).toBeVisible();
@@ -142,7 +129,6 @@ for (const [render, path] of [
     await expect(
       page.getByRole("status", { name: contract.loadingName, exact: true }),
     ).toBeHidden();
-    expect(pageChunkRequested).toBe(true);
   });
 
 test.skip(!validOwner, "remote ownership tests run through remote e2e targets");

--- a/apps/shell-e2e/src/remote-owner.spec.ts
+++ b/apps/shell-e2e/src/remote-owner.spec.ts
@@ -6,72 +6,84 @@ const contracts = {
     standalone: "remotes/home/",
     role: "heading",
     name: "Finance researcher & educator",
+    loadingName: "Loading home",
   },
   "home-carousel": {
     host: "",
     standalone: "remotes/home-carousel/",
     role: "region",
     name: "Featured work",
+    loadingName: "Loading featured work",
   },
   "home-cards": {
     host: "",
     standalone: "remotes/home-cards/",
     role: "region",
     name: "Areas of work",
+    loadingName: "Loading areas of work",
   },
   "home-story": {
     host: "",
     standalone: "remotes/home-story/",
     role: "heading",
     name: "Who am I?",
+    loadingName: "Loading story",
   },
   "home-contact": {
     host: "",
     standalone: "remotes/home-contact/",
     role: "heading",
     name: "Let’s build something useful.",
+    loadingName: "Loading contact options",
   },
   bio: {
     host: "bio",
     standalone: "remotes/bio/",
     role: "heading",
     name: "Optimizing Life",
+    loadingName: "Loading biography",
   },
   research: {
     host: "research",
     standalone: "remotes/research/",
     role: "heading",
     name: "Research Works",
+    loadingName: "Loading research",
   },
   software: {
     host: "software",
     standalone: "remotes/software/",
     role: "heading",
     name: "Open-Source Software",
+    loadingName: "Loading software",
   },
   courses: {
     host: "courses",
     standalone: "remotes/courses/",
     role: "heading",
     name: "Courses",
+    loadingName: "Loading courses",
   },
   timeline: {
     host: "",
     standalone: "remotes/timeline/",
     role: "heading",
     name: "Educated and Experienced",
+    loadingName: "Loading timeline",
   },
   skills: {
     host: "",
     standalone: "remotes/skills/",
     role: "heading",
     name: "Skilled in…",
+    loadingName: "Loading skills",
   },
   awards: {
     host: "",
     standalone: "remotes/awards/",
     role: "heading",
     name: "Selected awards",
+    loadingName: "Loading awards",
   },
 } as const;
 
@@ -98,6 +110,42 @@ for (const [render, path] of [
       page.getByRole(contract.role, { name: contract.name, exact: true }),
     ).toBeVisible();
     expect(failures).toEqual([]);
+  });
+
+for (const [render, path] of [
+  ["host-composed", contract.host],
+  ["standalone", contract.standalone],
+] as const)
+  test(`${owner} shows its skeleton while loading through its ${render} boundary`, async ({
+    page,
+  }) => {
+    let pageChunkRequested = false;
+    await page.route(`**/remotes/${owner}/*.js`, async (route) => {
+      const filename = new URL(route.request().url()).pathname
+        .split("/")
+        .at(-1);
+      const isPageChunk =
+        filename !== "remoteEntry.js" &&
+        !filename?.startsWith("main.") &&
+        !filename?.startsWith("__federation_expose_Skeleton.");
+      if (isPageChunk) {
+        pageChunkRequested = true;
+        await new Promise((resolve) => setTimeout(resolve, 1_000));
+      }
+      await route.continue();
+    });
+
+    await page.goto(path, { waitUntil: "domcontentloaded" });
+    await expect(
+      page.getByRole("status", { name: contract.loadingName, exact: true }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole(contract.role, { name: contract.name, exact: true }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("status", { name: contract.loadingName, exact: true }),
+    ).toBeHidden();
+    expect(pageChunkRequested).toBe(true);
   });
 
 test.skip(!validOwner, "remote ownership tests run through remote e2e targets");

--- a/apps/shell-e2e/src/skills.spec.ts
+++ b/apps/shell-e2e/src/skills.spec.ts
@@ -98,8 +98,10 @@ for (const renderPath of renderPaths) {
             ? "Loading skills…"
             : "Skills unavailable";
       await expect(
-        page.getByRole(state === "error" ? "alert" : "status"),
-      ).toContainText(expected);
+        page
+          .getByRole(state === "error" ? "alert" : "status")
+          .filter({ hasText: expected }),
+      ).toBeVisible();
     });
   }
 

--- a/apps/shell-e2e/src/unit/federation-contract.spec.ts
+++ b/apps/shell-e2e/src/unit/federation-contract.spec.ts
@@ -1,6 +1,10 @@
 import { readFile } from "node:fs/promises";
 import { describe, expect, it } from "vitest";
 
+const remoteManifest = JSON.parse(
+  await readFile("libs/build-config/src/remotes.json", "utf8"),
+) as Record<string, string>;
+
 const timelineContract = [
   ["apps/shell/project.json", '"timeline"'],
   ["libs/build-config/src/remotes.json", '"timeline": "timeline"'],
@@ -59,5 +63,58 @@ describe("awards federation contract", () => {
 describe("bio content contract", () => {
   it("keeps the remote and browser heading expectations in sync", async () => {
     await expectContract(bioContract);
+  });
+});
+
+function configuredRemotes(contents: string) {
+  const match = contents.match(/remoteMap\(\[([\s\S]*?)\]\)/);
+  const configuredList = match?.[1];
+  if (!configuredList)
+    throw new Error("Expected a remoteMap array in host configuration");
+  return [...configuredList.matchAll(/"([a-z][a-z0-9-]*)"/g)].map(
+    (remoteMatch) => {
+      const remote = remoteMatch[1];
+      const federationName = remote ? remoteManifest[remote] : undefined;
+      if (!federationName)
+        throw new Error(
+          `Configured remote ${String(remote)} has no manifest entry`,
+        );
+      return federationName;
+    },
+  );
+}
+
+function declaredSkeletons(contents: string) {
+  return [
+    ...contents.matchAll(/declare module "([A-Za-z][A-Za-z0-9]*)\/Skeleton"/g),
+  ]
+    .map((match) => {
+      const remote = match[1];
+      if (!remote) throw new Error("Skeleton declaration has no remote name");
+      return remote;
+    })
+    .sort();
+}
+
+describe("skeleton federation contract", () => {
+  it("keeps host ambient modules aligned with configured federation remotes", async () => {
+    const remoteConfig = await readFile(
+      "libs/build-config/src/rspack-remote.ts",
+      "utf8",
+    );
+    expect(remoteConfig).toContain('"./Skeleton": "./src/skeleton.tsx"');
+
+    for (const [hostConfigPath, declarationsPath] of [
+      ["apps/shell/rspack.config.ts", "apps/shell/src/remotes.d.ts"],
+      ["apps/home/rspack.config.ts", "apps/home/src/remotes.d.ts"],
+    ] as const) {
+      const [hostConfig, declarations] = await Promise.all([
+        readFile(hostConfigPath, "utf8"),
+        readFile(declarationsPath, "utf8"),
+      ]);
+      expect(declaredSkeletons(declarations), declarationsPath).toEqual(
+        configuredRemotes(hostConfig).sort(),
+      );
+    }
   });
 });

--- a/apps/shell-e2e/src/unit/federation-contract.spec.ts
+++ b/apps/shell-e2e/src/unit/federation-contract.spec.ts
@@ -1,10 +1,6 @@
 import { readFile } from "node:fs/promises";
 import { describe, expect, it } from "vitest";
 
-const remoteManifest = JSON.parse(
-  await readFile("libs/build-config/src/remotes.json", "utf8"),
-) as Record<string, string>;
-
 const timelineContract = [
   ["apps/shell/project.json", '"timeline"'],
   ["libs/build-config/src/remotes.json", '"timeline": "timeline"'],
@@ -63,58 +59,5 @@ describe("awards federation contract", () => {
 describe("bio content contract", () => {
   it("keeps the remote and browser heading expectations in sync", async () => {
     await expectContract(bioContract);
-  });
-});
-
-function configuredRemotes(contents: string) {
-  const match = contents.match(/remoteMap\(\[([\s\S]*?)\]\)/);
-  const configuredList = match?.[1];
-  if (!configuredList)
-    throw new Error("Expected a remoteMap array in host configuration");
-  return [...configuredList.matchAll(/"([a-z][a-z0-9-]*)"/g)].map(
-    (remoteMatch) => {
-      const remote = remoteMatch[1];
-      const federationName = remote ? remoteManifest[remote] : undefined;
-      if (!federationName)
-        throw new Error(
-          `Configured remote ${String(remote)} has no manifest entry`,
-        );
-      return federationName;
-    },
-  );
-}
-
-function declaredSkeletons(contents: string) {
-  return [
-    ...contents.matchAll(/declare module "([A-Za-z][A-Za-z0-9]*)\/Skeleton"/g),
-  ]
-    .map((match) => {
-      const remote = match[1];
-      if (!remote) throw new Error("Skeleton declaration has no remote name");
-      return remote;
-    })
-    .sort();
-}
-
-describe("skeleton federation contract", () => {
-  it("keeps host ambient modules aligned with configured federation remotes", async () => {
-    const remoteConfig = await readFile(
-      "libs/build-config/src/rspack-remote.ts",
-      "utf8",
-    );
-    expect(remoteConfig).toContain('"./Skeleton": "./src/skeleton.tsx"');
-
-    for (const [hostConfigPath, declarationsPath] of [
-      ["apps/shell/rspack.config.ts", "apps/shell/src/remotes.d.ts"],
-      ["apps/home/rspack.config.ts", "apps/home/src/remotes.d.ts"],
-    ] as const) {
-      const [hostConfig, declarations] = await Promise.all([
-        readFile(hostConfigPath, "utf8"),
-        readFile(declarationsPath, "utf8"),
-      ]);
-      expect(declaredSkeletons(declarations), declarationsPath).toEqual(
-        configuredRemotes(hostConfig).sort(),
-      );
-    }
   });
 });

--- a/apps/shell/src/app.tsx
+++ b/apps/shell/src/app.tsx
@@ -1,33 +1,70 @@
 import { SiteLayout } from "@site/layout";
+import BioSkeleton from "bio/Skeleton";
+import CoursesSkeleton from "courses/Skeleton";
+import HomeSkeleton from "home/Skeleton";
 import { lazy, Suspense } from "react";
 import { Navigate, Route, Routes } from "react-router-dom";
+import ResearchSkeleton from "research/Skeleton";
+import SoftwareSkeleton from "software/Skeleton";
 import { routes } from "./routes";
 
+// Static federated imports put the lightweight skeleton modules in the shell's
+// eager startup graph; only the Page imports below create lazy chunks.
 const HomePage = lazy(() => import("home/Page"));
 const BioPage = lazy(() => import("bio/Page"));
 const ResearchPage = lazy(() => import("research/Page"));
 const SoftwarePage = lazy(() => import("software/Page"));
 const CoursesPage = lazy(() => import("courses/Page"));
-function RemoteFallback() {
-  return <output className="placeholder">Loading page…</output>;
-}
 
 export function App() {
   const navigation = routes.map(({ path, label }) => ({ path, label }));
   return (
     <SiteLayout routes={navigation}>
-      <Suspense fallback={<RemoteFallback />}>
-        <Routes>
-          <Route path="/" element={<HomePage />} />
-          <Route path="/bio" element={<BioPage />} />
-          {/* llmlint: ignore[changed_behavior_has_e2e] The real-browser legacy story route journey covers this redirect and resulting remote. */}
-          <Route path="/story" element={<Navigate to="/bio" replace />} />
-          <Route path="/research" element={<ResearchPage />} />
-          <Route path="/software" element={<SoftwarePage />} />
-          <Route path="/courses" element={<CoursesPage />} />
-          <Route path="*" element={<Navigate to="/" replace />} />
-        </Routes>
-      </Suspense>
+      <Routes>
+        <Route
+          path="/"
+          element={
+            <Suspense fallback={<HomeSkeleton />}>
+              <HomePage />
+            </Suspense>
+          }
+        />
+        <Route
+          path="/bio"
+          element={
+            <Suspense fallback={<BioSkeleton />}>
+              <BioPage />
+            </Suspense>
+          }
+        />
+        {/* llmlint: ignore[changed_behavior_has_e2e] The real-browser legacy story route journey covers this redirect and resulting remote. */}
+        <Route path="/story" element={<Navigate to="/bio" replace />} />
+        <Route
+          path="/research"
+          element={
+            <Suspense fallback={<ResearchSkeleton />}>
+              <ResearchPage />
+            </Suspense>
+          }
+        />
+        <Route
+          path="/software"
+          element={
+            <Suspense fallback={<SoftwareSkeleton />}>
+              <SoftwarePage />
+            </Suspense>
+          }
+        />
+        <Route
+          path="/courses"
+          element={
+            <Suspense fallback={<CoursesSkeleton />}>
+              <CoursesPage />
+            </Suspense>
+          }
+        />
+        <Route path="*" element={<Navigate to="/" replace />} />
+      </Routes>
     </SiteLayout>
   );
 }

--- a/apps/shell/src/bootstrap.tsx
+++ b/apps/shell/src/bootstrap.tsx
@@ -1,0 +1,15 @@
+import "@site/design-system";
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { BrowserRouter } from "react-router-dom";
+import { App } from "./app";
+
+const root = document.getElementById("root");
+if (!root) throw new Error("Missing application root");
+createRoot(root).render(
+  <StrictMode>
+    <BrowserRouter basename="/nick-derobertis-site">
+      <App />
+    </BrowserRouter>
+  </StrictMode>,
+);

--- a/apps/shell/src/main.tsx
+++ b/apps/shell/src/main.tsx
@@ -1,15 +1,3 @@
-import { StrictMode } from "react";
-import { createRoot } from "react-dom/client";
-import { BrowserRouter } from "react-router-dom";
-import { App } from "./app";
-import "@site/design-system";
-
-const root = document.getElementById("root");
-if (!root) throw new Error("Missing application root");
-createRoot(root).render(
-  <StrictMode>
-    <BrowserRouter basename="/nick-derobertis-site">
-      <App />
-    </BrowserRouter>
-  </StrictMode>,
-);
+// Module Federation resolves the statically imported remote skeletons from the
+// asynchronous bootstrap chunk before React renders the shell.
+void import("./bootstrap");

--- a/apps/shell/src/remotes.d.ts
+++ b/apps/shell/src/remotes.d.ts
@@ -1,3 +1,5 @@
+/// <reference path="../../../libs/build-config/src/federation-modules.d.ts" />
+
 declare module "home/Page" {
   import type { ComponentType } from "react";
 
@@ -27,37 +29,6 @@ declare module "courses/Page" {
 
   const Page: ComponentType;
   export default Page;
-}
-
-declare module "home/Skeleton" {
-  import type { ComponentType } from "react";
-
-  const Skeleton: ComponentType;
-  export default Skeleton;
-}
-declare module "bio/Skeleton" {
-  import type { ComponentType } from "react";
-
-  const Skeleton: ComponentType;
-  export default Skeleton;
-}
-declare module "research/Skeleton" {
-  import type { ComponentType } from "react";
-
-  const Skeleton: ComponentType;
-  export default Skeleton;
-}
-declare module "software/Skeleton" {
-  import type { ComponentType } from "react";
-
-  const Skeleton: ComponentType;
-  export default Skeleton;
-}
-declare module "courses/Skeleton" {
-  import type { ComponentType } from "react";
-
-  const Skeleton: ComponentType;
-  export default Skeleton;
 }
 
 declare module "timeline/Page" {

--- a/apps/shell/src/remotes.d.ts
+++ b/apps/shell/src/remotes.d.ts
@@ -29,6 +29,37 @@ declare module "courses/Page" {
   export default Page;
 }
 
+declare module "home/Skeleton" {
+  import type { ComponentType } from "react";
+
+  const Skeleton: ComponentType;
+  export default Skeleton;
+}
+declare module "bio/Skeleton" {
+  import type { ComponentType } from "react";
+
+  const Skeleton: ComponentType;
+  export default Skeleton;
+}
+declare module "research/Skeleton" {
+  import type { ComponentType } from "react";
+
+  const Skeleton: ComponentType;
+  export default Skeleton;
+}
+declare module "software/Skeleton" {
+  import type { ComponentType } from "react";
+
+  const Skeleton: ComponentType;
+  export default Skeleton;
+}
+declare module "courses/Skeleton" {
+  import type { ComponentType } from "react";
+
+  const Skeleton: ComponentType;
+  export default Skeleton;
+}
+
 declare module "timeline/Page" {
   import type { ComponentType } from "react";
 

--- a/apps/skills/src/main.tsx
+++ b/apps/skills/src/main.tsx
@@ -1,7 +1,14 @@
 import "@site/design-system";
+import { lazy, Suspense } from "react";
 import { createRoot } from "react-dom/client";
-import SkillsPage from "./page";
+import Skeleton from "./skeleton";
+
+const SkillsPage = lazy(() => import("./page"));
 
 const root = document.getElementById("root");
 if (!root) throw new Error("Missing remote root");
-createRoot(root).render(<SkillsPage />);
+createRoot(root).render(
+  <Suspense fallback={<Skeleton />}>
+    <SkillsPage />
+  </Suspense>,
+);

--- a/apps/skills/src/skeleton.tsx
+++ b/apps/skills/src/skeleton.tsx
@@ -1,0 +1,16 @@
+export default function SkillsSkeleton() {
+  return (
+    <section
+      className="remote-skeleton skeleton-skills"
+      role="status"
+      aria-label="Loading skills"
+    >
+      <div className="skeleton-heading" />
+      <div className="skeleton-circle" />
+      <div className="skeleton-controls">
+        <i />
+        <i />
+      </div>
+    </section>
+  );
+}

--- a/apps/software/src/main.tsx
+++ b/apps/software/src/main.tsx
@@ -1,6 +1,14 @@
+import "@site/design-system";
+import { lazy, Suspense } from "react";
 import { createRoot } from "react-dom/client";
-import Page from "./page";
+import Skeleton from "./skeleton";
+
+const Page = lazy(() => import("./page"));
 
 const root = document.getElementById("root");
 if (!root) throw new Error("Missing remote root");
-createRoot(root).render(<Page />);
+createRoot(root).render(
+  <Suspense fallback={<Skeleton />}>
+    <Page />
+  </Suspense>,
+);

--- a/apps/software/src/skeleton.tsx
+++ b/apps/software/src/skeleton.tsx
@@ -1,0 +1,17 @@
+export default function SoftwareSkeleton() {
+  return (
+    <section
+      className="remote-skeleton skeleton-software"
+      role="status"
+      aria-label="Loading software"
+    >
+      <div className="skeleton-banner" />
+      <div className="skeleton-stats" />
+      <div className="skeleton-grid">
+        {[1, 2, 3, 4].map((item) => (
+          <i key={item} />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/timeline/src/main.tsx
+++ b/apps/timeline/src/main.tsx
@@ -1,7 +1,14 @@
 import "@site/design-system";
+import { lazy, Suspense } from "react";
 import { createRoot } from "react-dom/client";
-import TimelinePage from "./page";
+import Skeleton from "./skeleton";
+
+const TimelinePage = lazy(() => import("./page"));
 
 const root = document.getElementById("root");
 if (!root) throw new Error("Missing remote root");
-createRoot(root).render(<TimelinePage />);
+createRoot(root).render(
+  <Suspense fallback={<Skeleton />}>
+    <TimelinePage />
+  </Suspense>,
+);

--- a/apps/timeline/src/skeleton.tsx
+++ b/apps/timeline/src/skeleton.tsx
@@ -1,0 +1,16 @@
+export default function TimelineSkeleton() {
+  return (
+    <section
+      className="remote-skeleton skeleton-timeline"
+      role="status"
+      aria-label="Loading timeline"
+    >
+      <div className="skeleton-heading" />
+      <div className="skeleton-chart">
+        {[1, 2, 3, 4].map((item) => (
+          <i key={item} />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/libs/build-config/src/federation-modules.d.ts
+++ b/libs/build-config/src/federation-modules.d.ts
@@ -1,0 +1,8 @@
+// remoteConfig exposes this dependency-light contract for every remote, so
+// hosts do not maintain a second per-remote Skeleton module inventory.
+declare module "*/Skeleton" {
+  import type { ComponentType } from "react";
+
+  const Skeleton: ComponentType;
+  export default Skeleton;
+}

--- a/libs/build-config/src/rspack-remote.ts
+++ b/libs/build-config/src/rspack-remote.ts
@@ -67,7 +67,10 @@ export function remoteConfig(name: string, options: RemoteOptions = {}) {
       new ModuleFederationPlugin({
         name: federationName,
         filename: "remoteEntry.js",
-        exposes: { "./Page": "./src/page.tsx" },
+        exposes: {
+          "./Page": "./src/page.tsx",
+          "./Skeleton": "./src/skeleton.tsx",
+        },
         remotes: options.remotes ?? {},
         shared: {
           react: { singleton: true, requiredVersion: false, eager: true },

--- a/libs/design-system/src/theme.css
+++ b/libs/design-system/src/theme.css
@@ -276,6 +276,139 @@ a {
   border-left: 4px solid var(--blue);
   background: var(--sky);
 }
+
+.remote-skeleton {
+  display: grid;
+  gap: 1.5rem;
+  width: 100%;
+  padding: clamp(1.5rem, 4vw, 4rem);
+  overflow: hidden;
+}
+.remote-skeleton :is(i, b, div) {
+  border-radius: 0.75rem;
+}
+.remote-skeleton :is(i, b),
+.skeleton-heading,
+.skeleton-banner,
+.skeleton-hero,
+.skeleton-cover,
+.skeleton-portrait,
+.skeleton-circle,
+.skeleton-stats {
+  display: block;
+  background: linear-gradient(100deg, #e5e7eb 20%, #f8fafc 40%, #e5e7eb 60%);
+  background-size: 200% 100%;
+  animation: skeleton-pulse 1.4s ease-in-out infinite;
+}
+.skeleton-hero,
+.skeleton-banner {
+  min-height: 16rem;
+}
+.skeleton-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1rem;
+}
+.skeleton-grid > i {
+  min-height: 12rem;
+}
+.skeleton-heading {
+  width: min(28rem, 70%);
+  height: 4rem;
+}
+.skeleton-list {
+  display: grid;
+  gap: 1rem;
+}
+.skeleton-list > i {
+  height: 7rem;
+}
+.skeleton-bio {
+  grid-template-columns: minmax(12rem, 35%) 1fr;
+}
+.skeleton-cover {
+  min-height: 38rem;
+}
+.skeleton-copy {
+  display: grid;
+  align-content: center;
+  gap: 1rem;
+}
+.skeleton-copy > b {
+  width: 65%;
+  height: 3rem;
+}
+.skeleton-copy > i {
+  height: 1rem;
+}
+.skeleton-stats {
+  height: 6rem;
+}
+.skeleton-course {
+  height: 18rem;
+  background: #e5e7eb;
+}
+.skeleton-story,
+.skeleton-contact {
+  grid-template-columns: minmax(10rem, 35%) 1fr;
+}
+.skeleton-portrait {
+  min-height: 22rem;
+}
+.skeleton-links {
+  display: grid;
+  gap: 1rem;
+}
+.skeleton-links > i {
+  height: 3rem;
+}
+.skeleton-chart {
+  display: grid;
+  gap: 0.75rem;
+  padding: 2rem;
+  border: 1px solid #e5e7eb;
+}
+.skeleton-chart > i {
+  height: 2rem;
+}
+.skeleton-circle {
+  width: min(25rem, 80vw);
+  aspect-ratio: 1;
+  border-radius: 50%;
+  justify-self: center;
+}
+.skeleton-controls {
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+}
+.skeleton-controls > i {
+  width: 8rem;
+  height: 2.5rem;
+}
+@keyframes skeleton-pulse {
+  to {
+    background-position: -200% 0;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .remote-skeleton :is(i, b, div) {
+    animation: none;
+  }
+}
+@media (max-width: 48rem) {
+  .skeleton-grid {
+    grid-template-columns: 1fr;
+  }
+  .skeleton-bio,
+  .skeleton-story,
+  .skeleton-contact {
+    grid-template-columns: 1fr;
+  }
+  .skeleton-cover {
+    min-height: 16rem;
+  }
+}
 .software-page {
   display: grid;
   gap: clamp(2rem, 5vw, 4rem);

--- a/scripts/serve-e2e.mjs
+++ b/scripts/serve-e2e.mjs
@@ -1,7 +1,7 @@
 import { createReadStream } from "node:fs";
 import { stat } from "node:fs/promises";
 import { createServer } from "node:http";
-import { extname, join, normalize } from "node:path";
+import { basename, extname, join, normalize } from "node:path";
 import { fileURLToPath } from "node:url";
 import siteConfig from "../libs/data-access-core/src/site.config.json" with {
   type: "json",
@@ -31,13 +31,7 @@ if (!Number.isInteger(port) || port < 1 || port > 65_535)
     `PORT must be an integer from 1 to 65535; received ${JSON.stringify(portValue)}. Set a valid PORT and run just test-e2e again.`,
   );
 // llmlint: ignore-end[changed_behavior_has_e2e]
-const javaScriptAssetLatencyValue =
-  process.env.JAVASCRIPT_ASSET_LATENCY_MS ?? "0";
-if (!/^\d{1,4}$/.test(javaScriptAssetLatencyValue))
-  throw new Error(
-    `JAVASCRIPT_ASSET_LATENCY_MS must be an integer from 0 to 9999; received ${JSON.stringify(javaScriptAssetLatencyValue)}. Set a valid latency and run just test-e2e again.`,
-  );
-const javaScriptAssetLatencyMs = Number(javaScriptAssetLatencyValue);
+const remoteLazyAssetLatencyMs = 300;
 const types = {
   ".css": "text/css",
   ".html": "text/html",
@@ -72,9 +66,20 @@ const server = createServer(async (request, response) => {
     "Content-Type",
     types[extname(file)] ?? "application/octet-stream",
   );
-  if (javaScriptAssetLatencyMs > 0 && extname(file) === ".js")
+  const assetName = basename(file);
+  const isEagerRemoteAsset =
+    assetName.startsWith("main.") ||
+    assetName === "remoteEntry.js" ||
+    assetName.startsWith("common.") ||
+    assetName.startsWith("__federation_expose_Skeleton.");
+  if (
+    remoteLazyAssetLatencyMs > 0 &&
+    url.pathname.includes("/remotes/") &&
+    extname(file) === ".js" &&
+    !isEagerRemoteAsset
+  )
     await new Promise((resolve) =>
-      setTimeout(resolve, javaScriptAssetLatencyMs),
+      setTimeout(resolve, remoteLazyAssetLatencyMs),
     );
   createReadStream(file).pipe(response);
 });

--- a/scripts/serve-e2e.mjs
+++ b/scripts/serve-e2e.mjs
@@ -31,12 +31,13 @@ if (!Number.isInteger(port) || port < 1 || port > 65_535)
     `PORT must be an integer from 1 to 65535; received ${JSON.stringify(portValue)}. Set a valid PORT and run just test-e2e again.`,
   );
 // llmlint: ignore-end[changed_behavior_has_e2e]
-const staticAssetLatencyValue = process.env.STATIC_ASSET_LATENCY_MS ?? "0";
-if (!/^\d{1,4}$/.test(staticAssetLatencyValue))
+const javaScriptAssetLatencyValue =
+  process.env.JAVASCRIPT_ASSET_LATENCY_MS ?? "0";
+if (!/^\d{1,4}$/.test(javaScriptAssetLatencyValue))
   throw new Error(
-    `STATIC_ASSET_LATENCY_MS must be an integer from 0 to 9999; received ${JSON.stringify(staticAssetLatencyValue)}. Set a valid latency and run just test-e2e again.`,
+    `JAVASCRIPT_ASSET_LATENCY_MS must be an integer from 0 to 9999; received ${JSON.stringify(javaScriptAssetLatencyValue)}. Set a valid latency and run just test-e2e again.`,
   );
-const staticAssetLatencyMs = Number(staticAssetLatencyValue);
+const javaScriptAssetLatencyMs = Number(javaScriptAssetLatencyValue);
 const types = {
   ".css": "text/css",
   ".html": "text/html",
@@ -71,8 +72,10 @@ const server = createServer(async (request, response) => {
     "Content-Type",
     types[extname(file)] ?? "application/octet-stream",
   );
-  if (staticAssetLatencyMs > 0 && extname(file) === ".js")
-    await new Promise((resolve) => setTimeout(resolve, staticAssetLatencyMs));
+  if (javaScriptAssetLatencyMs > 0 && extname(file) === ".js")
+    await new Promise((resolve) =>
+      setTimeout(resolve, javaScriptAssetLatencyMs),
+    );
   createReadStream(file).pipe(response);
 });
 // llmlint: ignore-block[changed_behavior_has_e2e] Listen failures are exercised through the real serve-e2e subprocess with an occupied port in home.spec.ts; no browser can connect in this state.

--- a/scripts/serve-e2e.mjs
+++ b/scripts/serve-e2e.mjs
@@ -31,13 +31,18 @@ if (!Number.isInteger(port) || port < 1 || port > 65_535)
     `PORT must be an integer from 1 to 65535; received ${JSON.stringify(portValue)}. Set a valid PORT and run just test-e2e again.`,
   );
 // llmlint: ignore-end[changed_behavior_has_e2e]
+const staticAssetLatencyValue = process.env.STATIC_ASSET_LATENCY_MS ?? "0";
+if (!/^\d{1,4}$/.test(staticAssetLatencyValue))
+  throw new Error(
+    `STATIC_ASSET_LATENCY_MS must be an integer from 0 to 9999; received ${JSON.stringify(staticAssetLatencyValue)}. Set a valid latency and run just test-e2e again.`,
+  );
+const staticAssetLatencyMs = Number(staticAssetLatencyValue);
 const types = {
   ".css": "text/css",
   ".html": "text/html",
   ".js": "text/javascript",
   ".json": "application/json",
 };
-const remoteNamePattern = /^[a-z][a-z0-9-]*$/;
 const server = createServer(async (request, response) => {
   const url = new URL(request.url ?? "/", "http://localhost");
   if (
@@ -66,21 +71,8 @@ const server = createServer(async (request, response) => {
     "Content-Type",
     types[extname(file)] ?? "application/octet-stream",
   );
-  const referer = request.headers.referer
-    ? new URL(request.headers.referer)
-    : null;
-  const delayedRemote = referer?.searchParams.get("e2e-page-delay");
-  const filename = relative.split("/").at(-1);
-  const isDelayedPageChunk =
-    delayedRemote !== null &&
-    remoteNamePattern.test(delayedRemote) &&
-    relative.includes(`/remotes/${delayedRemote}/`) &&
-    extname(relative) === ".js" &&
-    filename !== "remoteEntry.js" &&
-    !filename?.startsWith("main.") &&
-    !filename?.startsWith("__federation_expose_Skeleton.");
-  if (isDelayedPageChunk)
-    await new Promise((resolve) => setTimeout(resolve, 1_000));
+  if (staticAssetLatencyMs > 0 && extname(file) === ".js")
+    await new Promise((resolve) => setTimeout(resolve, staticAssetLatencyMs));
   createReadStream(file).pipe(response);
 });
 // llmlint: ignore-block[changed_behavior_has_e2e] Listen failures are exercised through the real serve-e2e subprocess with an occupied port in home.spec.ts; no browser can connect in this state.

--- a/scripts/serve-e2e.mjs
+++ b/scripts/serve-e2e.mjs
@@ -37,6 +37,7 @@ const types = {
   ".js": "text/javascript",
   ".json": "application/json",
 };
+const remoteNamePattern = /^[a-z][a-z0-9-]*$/;
 const server = createServer(async (request, response) => {
   const url = new URL(request.url ?? "/", "http://localhost");
   if (
@@ -65,6 +66,21 @@ const server = createServer(async (request, response) => {
     "Content-Type",
     types[extname(file)] ?? "application/octet-stream",
   );
+  const referer = request.headers.referer
+    ? new URL(request.headers.referer)
+    : null;
+  const delayedRemote = referer?.searchParams.get("e2e-page-delay");
+  const filename = relative.split("/").at(-1);
+  const isDelayedPageChunk =
+    delayedRemote !== null &&
+    remoteNamePattern.test(delayedRemote) &&
+    relative.includes(`/remotes/${delayedRemote}/`) &&
+    extname(relative) === ".js" &&
+    filename !== "remoteEntry.js" &&
+    !filename?.startsWith("main.") &&
+    !filename?.startsWith("__federation_expose_Skeleton.");
+  if (isDelayedPageChunk)
+    await new Promise((resolve) => setTimeout(resolve, 1_000));
   createReadStream(file).pipe(response);
 });
 // llmlint: ignore-block[changed_behavior_has_e2e] Listen failures are exercised through the real serve-e2e subprocess with an occupied port in home.spec.ts; no browser can connect in this state.


### PR DESCRIPTION
## What
Give every microfrontend its own loading skeleton that lives with the remote and reflects the remote's own layout, and have the shell use each remote's skeleton as its Suspense fallback — the skeleton imported EAGERLY while the remote itself continues to load LAZILY.

- Each route remote (`home`, `bio`, `research`, `software`, `courses`, and any other feature remote the shell composes) exposes a lightweight `./Skeleton` module through its Module Federation config, alongside its existing `./Page` expose. The skeleton must be dependency-light (no `data-access` domain lib, no heavy chart/deps) so eagerly loading it is cheap — it mirrors the remote's structural layout (header block, card grid, chart placeholder, etc.) as static placeholder shapes.
- In `apps/shell/src/app.tsx`, replace the single generic `RemoteFallback` ("Loading page…") with per-route eager skeletons: import each remote's `Skeleton` eagerly (static `import Skeleton from "<remote>/Skeleton"`, NOT `lazy`), keep `Page` lazy, and give each route its own `<Suspense fallback={<XSkeleton />}>` so the correct app-shaped skeleton shows while that remote's `Page` chunk loads. Remove the generic `RemoteFallback`.
- Verify eager-vs-lazy actually holds: the skeleton module must be in the shell's initial/eager graph and the remote `Page` must remain a lazily-fetched chunk. If MF eager sharing needs config (e.g. `eager: true` on the shared skeleton or a non-lazy remote-module import path), wire it and note the mechanism in a comment.
- Keep standalone-remote render paths working: each remote should still render its own `Page` standalone, and its `Skeleton` should be usable/tested standalone too.

## Why
The loading UI should live where the structural knowledge lives: each app knows its own layout, so it should own the skeleton that mimics it, rather than the shell showing one generic "Loading page…" for everything. Eagerly loading the small skeleton while lazily loading the app improves perceived load and gives an accurate structural placeholder per feature.
