### PR TITLE
feat(ci): adopt screencomp aggregated visual comments (v0.4.4)

### DIFF
--- a/.github/workflows/visual-docs.yml
+++ b/.github/workflows/visual-docs.yml
@@ -78,13 +78,17 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: nickderobertis/screencomp/.github/workflows/visual-docs-reusable.yml@v0.4.3
+    uses: nickderobertis/screencomp/.github/workflows/visual-docs-reusable.yml@v0.4.4
     with:
       projects: ${{ needs.affected.outputs.projects || '[]' }}
       container: mcr.microsoft.com/playwright:v1.61.1-noble
-      screencomp-version: v0.4.3
+      screencomp-version: v0.4.4
       gallery-title: Nick DeRobertis site visual docs
       fail-on-drift: true
+      # One aggregated PR comment covering all affected microfrontends, instead of
+      # one sticky comment per app (12 apps -> 1 comment). Galleries and Pages
+      # output are unchanged; only the PR-comment surface consolidates.
+      comment-mode: aggregated
       # Each affected app is built (with the composed shell + home remotes its
       # host-composed shots need, via the Nx screenshot target's dependsOn) and
       # captured to $SHOTS_OUT. Runs twice for screencomp's reproducibility gate.

--- a/justfile
+++ b/justfile
@@ -14,7 +14,7 @@ bootstrap:
     log=$(mktemp); trap 'rm -f "$log"' EXIT; pnpm install --frozen-lockfile --reporter=silent >"$log" 2>&1 || { cat "$log" >&2; echo "bootstrap: dependency install failed; check the lockfile and registry access, then rerun just bootstrap" >&2; exit 1; }
     scripts/setup-ci-tools.sh || { echo "bootstrap: pinned CI tool installation failed; check the reported checksum or network error, then rerun just bootstrap" >&2; exit 1; }
     log=$(mktemp); trap 'rm -f "$log"' EXIT; pnpm exec playwright install chromium >"$log" 2>&1 || { cat "$log" >&2; echo "bootstrap: Chromium install failed; check Playwright system requirements, then rerun just bootstrap" >&2; exit 1; }
-    if ! command -v screencomp >/dev/null; then log=$(mktemp); trap 'rm -f "$log"' EXIT; (curl -fsSL https://raw.githubusercontent.com/nickderobertis/screencomp/main/scripts/install.sh | sh -s -- --version v0.4.3) >"$log" 2>&1 || { cat "$log" >&2; echo "bootstrap: screencomp install failed; check network access and rerun just bootstrap" >&2; exit 1; }; fi
+    if ! command -v screencomp >/dev/null; then log=$(mktemp); trap 'rm -f "$log"' EXIT; (curl -fsSL https://raw.githubusercontent.com/nickderobertis/screencomp/main/scripts/install.sh | sh -s -- --version v0.4.4) >"$log" 2>&1 || { cat "$log" >&2; echo "bootstrap: screencomp install failed; check network access and rerun just bootstrap" >&2; exit 1; }; fi
 
 bootstrap-ci:
     log=$(mktemp); trap 'rm -f "$log"' EXIT; pnpm install --frozen-lockfile --reporter=silent >"$log" 2>&1 || { cat "$log" >&2; echo "bootstrap-ci: dependency install failed; check the lockfile and registry access, then rerun just bootstrap-ci" >&2; exit 1; }

--- a/visual-tools.json
+++ b/visual-tools.json
@@ -1,5 +1,5 @@
 {
   "architecture": "x86_64",
   "playwrightContainer": "mcr.microsoft.com/playwright:v1.61.1-noble",
-  "screencompVersion": "v0.4.3"
+  "screencompVersion": "v0.4.4"
 }


### PR DESCRIPTION
## What

Bump screencomp to **v0.4.4** and set `comment-mode: aggregated` on the reusable visual-docs workflow, so a PR gets **one** combined visual-diff comment covering all affected microfrontends instead of one sticky comment per app (12 → 1). Galleries and GitHub Pages output are unchanged.

## Why

After adopting the canonical reusable workflow (#42), each PR posted 12 per-app comments — correct but noisy. screencomp v0.4.4 added an aggregated single-comment mode; this enables it. Verified locally: `verify-visual-contract` passes (all version pins consistent).