### PR TITLE
feat(loading): render each app's skeleton during data-loading

### DIFF
--- a/apps/awards/src/page.tsx
+++ b/apps/awards/src/page.tsx
@@ -4,19 +4,18 @@ import {
   selectedAwards,
 } from "@site/data-access-awards";
 import { AwardEmblem } from "./award-emblem";
+import Skeleton from "./skeleton";
 import { useAwards } from "./use-awards";
 import "./awards.css";
 
-function State({ name }: { name: "loading" | "error" | "empty" }) {
+function State({ name }: { name: "error" | "empty" }) {
   const copy =
-    name === "loading"
-      ? ["Loading awards…", "Gathering honors and achievements."]
-      : name === "error"
-        ? [
-            "Awards unavailable",
-            "Awards could not be loaded. Please try again later.",
-          ]
-        : ["No awards yet", "New honors and achievements will appear here."];
+    name === "error"
+      ? [
+          "Awards unavailable",
+          "Awards could not be loaded. Please try again later.",
+        ]
+      : ["No awards yet", "New honors and achievements will appear here."];
   return (
     <section
       className="awards-state"
@@ -30,6 +29,7 @@ function State({ name }: { name: "loading" | "error" | "empty" }) {
 
 export default function AwardsPage() {
   const state = useAwards();
+  if (state.name === "loading") return <Skeleton />;
   if (state.name !== "ready") return <State name={state.name} />;
   if (state.awards.length === 0) return <State name="empty" />;
   const showAll =

--- a/apps/awards/visual/baseline/x86_64.json
+++ b/apps/awards/visual/baseline/x86_64.json
@@ -58,6 +58,15 @@
     {
       "name": "awards",
       "toggles": {
+        "render": "host-composed",
+        "state": "loading",
+        "viewport": "desktop"
+      },
+      "hash": "039677df1a83beac3a7173b5c2058918e28bf103c463ec032b594b005cb16834"
+    },
+    {
+      "name": "awards",
+      "toggles": {
         "render": "standalone",
         "state": "all",
         "viewport": "desktop"
@@ -116,7 +125,7 @@
         "state": "loading",
         "viewport": "desktop"
       },
-      "hash": "ee92065926d4090c1304e7e61718eb871537f28dee92132b9c9adca0df77ff69"
+      "hash": "9adb3b72a382b66f0dd851e81588c5b51f1f6e7b337d0f1336f14eb7da2a34a4"
     }
   ]
 }

--- a/apps/awards/visual/baseline/x86_64.json
+++ b/apps/awards/visual/baseline/x86_64.json
@@ -58,15 +58,6 @@
     {
       "name": "awards",
       "toggles": {
-        "render": "host-composed",
-        "state": "loading",
-        "viewport": "desktop"
-      },
-      "hash": "039677df1a83beac3a7173b5c2058918e28bf103c463ec032b594b005cb16834"
-    },
-    {
-      "name": "awards",
-      "toggles": {
         "render": "standalone",
         "state": "all",
         "viewport": "desktop"

--- a/apps/bio/src/page.tsx
+++ b/apps/bio/src/page.tsx
@@ -1,5 +1,6 @@
 import "@site/design-system";
 import { useEffect, useState } from "react";
+import Skeleton from "./skeleton";
 import "./bio.css";
 
 function Marker({ children }: { children: string }) {
@@ -104,11 +105,10 @@ function Biography() {
   );
 }
 
-function BioState({ state }: { state: "empty" | "error" | "loading" }) {
+function BioState({ state }: { state: "empty" | "error" }) {
   const content = {
     empty: ["Biography coming soon", "There is no biography to show yet."],
     error: ["Biography unavailable", "The biography could not be displayed."],
-    loading: ["Loading biography", "Preparing Nick's story…"],
   } as const;
   const [heading, detail] = content[state];
   return (
@@ -131,7 +131,7 @@ export default function BioPage() {
     const timer = window.setTimeout(() => setLoading(false), 500);
     return () => window.clearTimeout(timer);
   }, [loading]);
-  if (loading) return <BioState state="loading" />;
+  if (loading) return <Skeleton />;
   if (scenario === "empty" || scenario === "error")
     return <BioState state={scenario} />;
   // llmlint: ignore-end[changed_behavior_has_e2e]

--- a/apps/bio/visual/baseline/x86_64.json
+++ b/apps/bio/visual/baseline/x86_64.json
@@ -49,15 +49,6 @@
     {
       "name": "bio",
       "toggles": {
-        "render": "host-composed",
-        "state": "loading",
-        "viewport": "desktop"
-      },
-      "hash": "c7b3e3c10ba3a481f2b40402dd5d9c3daa225f4d50bde8c11f7ed5911544276a"
-    },
-    {
-      "name": "bio",
-      "toggles": {
         "render": "standalone",
         "state": "empty",
         "viewport": "desktop"

--- a/apps/bio/visual/baseline/x86_64.json
+++ b/apps/bio/visual/baseline/x86_64.json
@@ -49,6 +49,15 @@
     {
       "name": "bio",
       "toggles": {
+        "render": "host-composed",
+        "state": "loading",
+        "viewport": "desktop"
+      },
+      "hash": "c7b3e3c10ba3a481f2b40402dd5d9c3daa225f4d50bde8c11f7ed5911544276a"
+    },
+    {
+      "name": "bio",
+      "toggles": {
         "render": "standalone",
         "state": "empty",
         "viewport": "desktop"
@@ -98,7 +107,7 @@
         "state": "loading",
         "viewport": "desktop"
       },
-      "hash": "eb821a07bfb5f2313b4b800bb43a4b828007897d3be0ebaa40eaa1cc70a638aa"
+      "hash": "04081ee2eb3cea13c70c2e0e9cd4c00eae3b0258e3bf1f7ba345863b5d3b5932"
     }
   ]
 }

--- a/apps/courses/src/page.tsx
+++ b/apps/courses/src/page.tsx
@@ -6,6 +6,7 @@ import {
 import { buildCourseDetails } from "@site/data-access-courses";
 import "@site/design-system";
 import { useEffect, useState } from "react";
+import Skeleton from "./skeleton";
 import "./courses.css";
 
 type CoursesView = "default" | "empty" | "error" | "loading";
@@ -245,6 +246,7 @@ function CourseCollection({ courses }: { courses: Course[] }) {
 export default function CoursesPage() {
   const view = useCoursesView();
   const courses = cvDataClient.domain("courses");
+  if (view === "loading") return <Skeleton />;
   return (
     <section className="courses-page">
       <header className="courses-banner">
@@ -255,11 +257,7 @@ export default function CoursesPage() {
           courses, topics, and teaching resources below.
         </p>
       </header>
-      {view === "loading" ? (
-        <div className="courses-state" role="status">
-          Loading courses…
-        </div>
-      ) : view === "error" ? (
+      {view === "error" ? (
         <div className="courses-state courses-state-error" role="alert">
           <h2>Courses are unavailable</h2>
           <p>Please try again later.</p>

--- a/apps/courses/visual/baseline/x86_64.json
+++ b/apps/courses/visual/baseline/x86_64.json
@@ -49,15 +49,6 @@
     {
       "name": "courses",
       "toggles": {
-        "render": "host-composed",
-        "state": "loading",
-        "viewport": "desktop"
-      },
-      "hash": "6b29566d6b86fe038cfb489ae79acddd4f9233df79a136e48a6ef2d9417cb2cc"
-    },
-    {
-      "name": "courses",
-      "toggles": {
         "render": "standalone",
         "state": "empty",
         "viewport": "desktop"

--- a/apps/courses/visual/baseline/x86_64.json
+++ b/apps/courses/visual/baseline/x86_64.json
@@ -49,6 +49,15 @@
     {
       "name": "courses",
       "toggles": {
+        "render": "host-composed",
+        "state": "loading",
+        "viewport": "desktop"
+      },
+      "hash": "6b29566d6b86fe038cfb489ae79acddd4f9233df79a136e48a6ef2d9417cb2cc"
+    },
+    {
+      "name": "courses",
+      "toggles": {
         "render": "standalone",
         "state": "empty",
         "viewport": "desktop"
@@ -98,7 +107,7 @@
         "state": "loading",
         "viewport": "desktop"
       },
-      "hash": "8c8b0845b35c489b7434496c76f7335a1f8703ffce62d7742ab8489b2bb1099e"
+      "hash": "415925300e15768c50191e08fa56d66bd0d1c596dc2365ab0b7a2ff96e968140"
     }
   ]
 }

--- a/apps/home-cards/src/page.tsx
+++ b/apps/home-cards/src/page.tsx
@@ -1,11 +1,11 @@
 import { siteBase } from "@site/data-access-core";
 import { homeContent, readPaneState } from "@site/data-access-home";
+import Skeleton from "./skeleton";
 import "./cards.css";
 
 export default function HomeCardsPage() {
   const state = readPaneState(window.location.search);
-  if (state === "loading")
-    return <output className="pane-state">Loading areas of work…</output>;
+  if (state === "loading") return <Skeleton />;
   if (state === "error")
     return (
       <output className="pane-state">Areas of work could not be loaded.</output>

--- a/apps/home-cards/visual/baseline/x86_64.json
+++ b/apps/home-cards/visual/baseline/x86_64.json
@@ -49,6 +49,15 @@
     {
       "name": "home-cards",
       "toggles": {
+        "render": "host-composed",
+        "state": "loading",
+        "viewport": "desktop"
+      },
+      "hash": "7990c7c982de121caf5612a9ffc93a22818d2f45c411e1398e9f149fbd3d44d4"
+    },
+    {
+      "name": "home-cards",
+      "toggles": {
         "render": "standalone",
         "state": "empty",
         "viewport": "desktop"
@@ -98,7 +107,7 @@
         "state": "loading",
         "viewport": "desktop"
       },
-      "hash": "73f24eb27ffed1cfbc844875eb59ad983d72e2d8205c8ee47d127b8ca51932eb"
+      "hash": "9adb3b72a382b66f0dd851e81588c5b51f1f6e7b337d0f1336f14eb7da2a34a4"
     }
   ]
 }

--- a/apps/home-cards/visual/baseline/x86_64.json
+++ b/apps/home-cards/visual/baseline/x86_64.json
@@ -49,15 +49,6 @@
     {
       "name": "home-cards",
       "toggles": {
-        "render": "host-composed",
-        "state": "loading",
-        "viewport": "desktop"
-      },
-      "hash": "7990c7c982de121caf5612a9ffc93a22818d2f45c411e1398e9f149fbd3d44d4"
-    },
-    {
-      "name": "home-cards",
-      "toggles": {
         "render": "standalone",
         "state": "empty",
         "viewport": "desktop"

--- a/apps/home-carousel/src/page.tsx
+++ b/apps/home-carousel/src/page.tsx
@@ -1,6 +1,7 @@
 import { siteBase } from "@site/data-access-core";
 import { homeContent, readPaneState } from "@site/data-access-home";
 import { useEffect, useState } from "react";
+import Skeleton from "./skeleton";
 import "./carousel.css";
 
 function useCarousel(length: number, enabled: boolean) {
@@ -18,10 +19,9 @@ function useCarousel(length: number, enabled: boolean) {
   return { active, move };
 }
 
-function StateMessage({ state }: { state: "empty" | "loading" | "error" }) {
+function StateMessage({ state }: { state: "empty" | "error" }) {
   const messages = {
     empty: "No featured stories are available yet.",
-    loading: "Loading featured stories…",
     error: "Featured stories could not be loaded.",
   };
   return <output className="pane-state">{messages[state]}</output>;
@@ -33,6 +33,7 @@ export default function HomeCarouselPage() {
     homeContent.carousel.length,
     state === "happy",
   );
+  if (state === "loading") return <Skeleton />;
   if (state !== "happy") return <StateMessage state={state} />;
   const slide = homeContent.carousel[active] ?? homeContent.carousel[0];
   return (

--- a/apps/home-carousel/visual/baseline/x86_64.json
+++ b/apps/home-carousel/visual/baseline/x86_64.json
@@ -49,15 +49,6 @@
     {
       "name": "home-carousel",
       "toggles": {
-        "render": "host-composed",
-        "state": "loading",
-        "viewport": "desktop"
-      },
-      "hash": "0dadf10549a9953b0b1251fc14a8e14f6b4c6e73ad9411ee85d5adf5c29b79e5"
-    },
-    {
-      "name": "home-carousel",
-      "toggles": {
         "render": "standalone",
         "state": "empty",
         "viewport": "desktop"

--- a/apps/home-carousel/visual/baseline/x86_64.json
+++ b/apps/home-carousel/visual/baseline/x86_64.json
@@ -49,6 +49,15 @@
     {
       "name": "home-carousel",
       "toggles": {
+        "render": "host-composed",
+        "state": "loading",
+        "viewport": "desktop"
+      },
+      "hash": "0dadf10549a9953b0b1251fc14a8e14f6b4c6e73ad9411ee85d5adf5c29b79e5"
+    },
+    {
+      "name": "home-carousel",
+      "toggles": {
         "render": "standalone",
         "state": "empty",
         "viewport": "desktop"
@@ -98,7 +107,7 @@
         "state": "loading",
         "viewport": "desktop"
       },
-      "hash": "5fb7a0daaa3aa588f9da550d8e0cba0dbe44808e1d221f035ae4af474f2f9aa6"
+      "hash": "1e857bd0c664ecca1639ed3a21823df4955fee2e73c5a5de0c67fc9d85b47443"
     }
   ]
 }

--- a/apps/home-contact/src/page.tsx
+++ b/apps/home-contact/src/page.tsx
@@ -1,10 +1,10 @@
 import { homeContent, readPaneState } from "@site/data-access-home";
+import Skeleton from "./skeleton";
 import "./contact.css";
 
 export default function HomeContactPage() {
   const state = readPaneState(window.location.search);
-  if (state === "loading")
-    return <output className="pane-state">Loading contact options…</output>;
+  if (state === "loading") return <Skeleton />;
   if (state === "error")
     return (
       <output className="pane-state">

--- a/apps/home-contact/visual/baseline/x86_64.json
+++ b/apps/home-contact/visual/baseline/x86_64.json
@@ -49,6 +49,15 @@
     {
       "name": "home-contact",
       "toggles": {
+        "render": "host-composed",
+        "state": "loading",
+        "viewport": "desktop"
+      },
+      "hash": "3c7dd2422ab858efcb02392b7d22159b61fa554636fd66ffb093436294689f8a"
+    },
+    {
+      "name": "home-contact",
+      "toggles": {
         "render": "standalone",
         "state": "empty",
         "viewport": "desktop"
@@ -98,7 +107,7 @@
         "state": "loading",
         "viewport": "desktop"
       },
-      "hash": "800627867531ba4c58b704f1836f76c64f9a3aae776dfe2c76c6ad98490a22c9"
+      "hash": "f42f7ac5386460cd83780727b67a983df9d0335fabcc3d4f3b54dc9ed368fdf1"
     }
   ]
 }

--- a/apps/home-contact/visual/baseline/x86_64.json
+++ b/apps/home-contact/visual/baseline/x86_64.json
@@ -49,15 +49,6 @@
     {
       "name": "home-contact",
       "toggles": {
-        "render": "host-composed",
-        "state": "loading",
-        "viewport": "desktop"
-      },
-      "hash": "3c7dd2422ab858efcb02392b7d22159b61fa554636fd66ffb093436294689f8a"
-    },
-    {
-      "name": "home-contact",
-      "toggles": {
         "render": "standalone",
         "state": "empty",
         "viewport": "desktop"

--- a/apps/home-story/src/page.tsx
+++ b/apps/home-story/src/page.tsx
@@ -1,11 +1,11 @@
 import { siteBase } from "@site/data-access-core";
 import { homeContent, readPaneState } from "@site/data-access-home";
+import Skeleton from "./skeleton";
 import "./story.css";
 
 export default function HomeStoryPage() {
   const state = readPaneState(window.location.search);
-  if (state === "loading")
-    return <output className="pane-state">Loading Nick’s story…</output>;
+  if (state === "loading") return <Skeleton />;
   if (state === "error")
     return (
       <output className="pane-state">Nick’s story could not be loaded.</output>

--- a/apps/home-story/visual/baseline/x86_64.json
+++ b/apps/home-story/visual/baseline/x86_64.json
@@ -49,6 +49,15 @@
     {
       "name": "home-story",
       "toggles": {
+        "render": "host-composed",
+        "state": "loading",
+        "viewport": "desktop"
+      },
+      "hash": "466ae17872b24a5a6a8ec7a3acb0186b5a94f7c77261c913d83ab16b8b200e75"
+    },
+    {
+      "name": "home-story",
+      "toggles": {
         "render": "standalone",
         "state": "empty",
         "viewport": "desktop"
@@ -98,7 +107,7 @@
         "state": "loading",
         "viewport": "desktop"
       },
-      "hash": "48de27c72cac5a03cb1e4d3903e33c6775adcc9144009c7720c258d622c14a75"
+      "hash": "4591783259647e47852121175553e755c8b7eba5bf2c22cf50ab85d59813415a"
     }
   ]
 }

--- a/apps/home-story/visual/baseline/x86_64.json
+++ b/apps/home-story/visual/baseline/x86_64.json
@@ -49,15 +49,6 @@
     {
       "name": "home-story",
       "toggles": {
-        "render": "host-composed",
-        "state": "loading",
-        "viewport": "desktop"
-      },
-      "hash": "466ae17872b24a5a6a8ec7a3acb0186b5a94f7c77261c913d83ab16b8b200e75"
-    },
-    {
-      "name": "home-story",
-      "toggles": {
         "render": "standalone",
         "state": "empty",
         "viewport": "desktop"

--- a/apps/research/src/page.tsx
+++ b/apps/research/src/page.tsx
@@ -1,16 +1,16 @@
 import { ResearchContent } from "./research-content";
+import Skeleton from "./skeleton";
 import { useResearch } from "./use-research";
 import "@site/design-system";
 import "./research.css";
 
-function StateMessage({ state }: { state: "empty" | "loading" | "error" }) {
+function StateMessage({ state }: { state: "empty" | "error" }) {
   const messages = {
     empty: ["No research projects yet", "New research will appear here."],
     error: [
       "Research is unavailable",
       "The research collection could not be loaded. Please try again later.",
     ],
-    loading: ["Loading research", "Gathering working papers and projects…"],
   } as const;
   const [heading, detail] = messages[state];
   return (
@@ -23,6 +23,7 @@ function StateMessage({ state }: { state: "empty" | "loading" | "error" }) {
 
 export default function ResearchPage() {
   const state = useResearch();
+  if (state.name === "loading") return <Skeleton />;
   if (state.name !== "ready") return <StateMessage state={state.name} />;
   if (!state.research.projects?.length) return <StateMessage state="empty" />;
   return <ResearchContent research={state.research} />;

--- a/apps/research/visual/baseline/x86_64.json
+++ b/apps/research/visual/baseline/x86_64.json
@@ -49,6 +49,15 @@
     {
       "name": "research",
       "toggles": {
+        "render": "host-composed",
+        "state": "loading",
+        "viewport": "desktop"
+      },
+      "hash": "3855d432c4a1887969a82b348e50e49545041db9ae9829ede1d63d735fbedb98"
+    },
+    {
+      "name": "research",
+      "toggles": {
         "render": "standalone",
         "state": "empty",
         "viewport": "desktop"
@@ -98,7 +107,7 @@
         "state": "loading",
         "viewport": "desktop"
       },
-      "hash": "5e2761e80ca43f82ceefb20c2ce8452f6cd92ff369ce8c7e52e7460b3874eebf"
+      "hash": "93396c54d6b22f055bfba414a0ae8efbad0e5208c8d2607ff70701cdb49daf50"
     }
   ]
 }

--- a/apps/research/visual/baseline/x86_64.json
+++ b/apps/research/visual/baseline/x86_64.json
@@ -49,15 +49,6 @@
     {
       "name": "research",
       "toggles": {
-        "render": "host-composed",
-        "state": "loading",
-        "viewport": "desktop"
-      },
-      "hash": "3855d432c4a1887969a82b348e50e49545041db9ae9829ede1d63d735fbedb98"
-    },
-    {
-      "name": "research",
-      "toggles": {
         "render": "standalone",
         "state": "empty",
         "viewport": "desktop"

--- a/apps/shell-e2e/src/awards.spec.ts
+++ b/apps/shell-e2e/src/awards.spec.ts
@@ -90,14 +90,13 @@ for (const renderPath of renderPaths) {
       });
     }
 
-    test("renders loading while the awards boundary is pending", async ({
+    test("renders its skeleton while the awards boundary is pending", async ({
       page,
     }) => {
       await page.goto(`${renderPath.path}?awards-scenario=loading`);
-      const loading = page
-        .getByRole("status")
-        .filter({ hasText: "Loading awards…" });
-      await expect(loading).toContainText("Loading awards…");
+      await expect(
+        page.getByRole("status", { name: "Loading awards", exact: true }),
+      ).toBeVisible();
       await expect(
         page.getByRole("heading", { name: "Selected awards" }),
       ).toBeAttached();

--- a/apps/shell-e2e/src/bio.spec.ts
+++ b/apps/shell-e2e/src/bio.spec.ts
@@ -33,7 +33,9 @@ for (const renderPath of renderPaths) {
     page,
   }) => {
     await page.goto(`${renderPath.path}?bio-view=loading`);
-    await expect(page.getByRole("status")).toContainText("Loading biography");
+    await expect(
+      page.getByRole("status", { name: "Loading biography", exact: true }),
+    ).toBeVisible();
     await expectBiography(page);
 
     await page.goto(`${renderPath.path}?bio-view=empty`);

--- a/apps/shell-e2e/src/courses.spec.ts
+++ b/apps/shell-e2e/src/courses.spec.ts
@@ -83,8 +83,15 @@ for (const renderPath of renderPaths) {
   test(`${renderPath.name} exposes loading, empty, and error states`, async ({
     page,
   }) => {
-    await openCourses(page, renderPath.path, "loading");
-    await expect(page.getByRole("status")).toHaveText("Loading courses…");
+    await page.goto(`${renderPath.path}?courses-view=loading`, {
+      waitUntil: "domcontentloaded",
+    });
+    await expect(
+      page.getByRole("status", { name: "Loading courses", exact: true }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Courses", exact: true }),
+    ).toBeVisible();
 
     await openCourses(page, renderPath.path, "empty");
     await expect(page.getByRole("status")).toContainText("No courses to show");

--- a/apps/shell-e2e/src/home.spec.ts
+++ b/apps/shell-e2e/src/home.spec.ts
@@ -9,27 +9,27 @@ const panes = [
   {
     remote: "home-carousel",
     happy: { role: "region" as const, name: "Featured work" },
+    loadingName: "Loading featured work",
     states: {
       empty: "No featured stories are available yet.",
-      loading: "Loading featured stories…",
       error: "Featured stories could not be loaded.",
     },
   },
   {
     remote: "home-cards",
     happy: { role: "region" as const, name: "Areas of work" },
+    loadingName: "Loading areas of work",
     states: {
       empty: "No areas of work are available yet.",
-      loading: "Loading areas of work…",
       error: "Areas of work could not be loaded.",
     },
   },
   {
     remote: "home-story",
     happy: { role: "heading" as const, name: "Who am I?" },
+    loadingName: "Loading story",
     states: {
       empty: "No story is available yet.",
-      loading: "Loading Nick’s story…",
       error: "Nick’s story could not be loaded.",
     },
   },
@@ -39,9 +39,9 @@ const panes = [
       role: "heading" as const,
       name: "Let’s build something useful.",
     },
+    loadingName: "Loading contact options",
     states: {
       empty: "No contact options are available.",
-      loading: "Loading contact options…",
       error: "Contact options could not be loaded.",
     },
   },
@@ -60,6 +60,15 @@ for (const pane of panes) {
       await page.goto(path.url(pane.remote));
       await expect(
         page.getByRole(pane.happy.role, { name: pane.happy.name }),
+      ).toBeVisible();
+    });
+
+    test(`${pane.remote} loading state shows its skeleton ${path.name}`, async ({
+      page,
+    }) => {
+      await page.goto(`${path.url(pane.remote)}?state=loading`);
+      await expect(
+        page.getByRole("status", { name: pane.loadingName, exact: true }),
       ).toBeVisible();
     });
 
@@ -109,9 +118,14 @@ for (const path of renderPaths)
       await page.goto(`${url}?state=${state}`);
       await expect(page.getByRole("status")).toHaveCount(4);
       for (const pane of panes)
-        await expect(
-          page.getByRole("status").filter({ hasText: pane.states[state] }),
-        ).toBeVisible();
+        if (state === "loading")
+          await expect(
+            page.getByRole("status", { name: pane.loadingName, exact: true }),
+          ).toBeVisible();
+        else
+          await expect(
+            page.getByRole("status").filter({ hasText: pane.states[state] }),
+          ).toBeVisible();
     });
 
 for (const path of renderPaths)
@@ -121,13 +135,17 @@ for (const path of renderPaths)
     }) => {
       const url = path.name === "standalone" ? "remotes/home/" : "";
       await page.goto(`${url}?timeline-state=${state}`);
+      if (state === "loading") {
+        await expect(
+          page.getByRole("status", { name: "Loading timeline", exact: true }),
+        ).toBeVisible();
+        return;
+      }
       const role = state === "error" ? "alert" : "status";
       const message =
         state === "empty"
           ? "No education or employment entries are available."
-          : state === "loading"
-            ? "Loading timeline…"
-            : "Timeline unavailable";
+          : "Timeline unavailable";
       await expect(
         page.getByRole(role).filter({ hasText: message }),
       ).toBeVisible();

--- a/apps/shell-e2e/src/research.spec.ts
+++ b/apps/shell-e2e/src/research.spec.ts
@@ -82,12 +82,12 @@ for (const renderPath of renderPaths) {
       });
     }
 
-    test("shows loading while the data boundary is pending, then renders", async ({
+    test("shows its skeleton while the data boundary is pending, then renders", async ({
       page,
     }) => {
       await page.goto(`${renderPath.path}?research-scenario=loading`);
       await expect(
-        page.getByRole("heading", { name: "Loading research" }),
+        page.getByRole("status", { name: "Loading research", exact: true }),
       ).toBeVisible();
       await expect(
         page.getByRole("heading", { name: "Research Works" }),

--- a/apps/shell-e2e/src/skills.spec.ts
+++ b/apps/shell-e2e/src/skills.spec.ts
@@ -91,12 +91,14 @@ for (const renderPath of renderPaths) {
   for (const state of ["empty", "loading", "error"] as const) {
     test(`${renderPath.name} presents its ${state} state`, async ({ page }) => {
       await openSkills(page, renderPath.url, state);
+      if (state === "loading") {
+        await expect(
+          page.getByRole("status", { name: "Loading skills", exact: true }),
+        ).toBeVisible();
+        return;
+      }
       const expected =
-        state === "empty"
-          ? "No skills are available."
-          : state === "loading"
-            ? "Loading skills…"
-            : "Skills unavailable";
+        state === "empty" ? "No skills are available." : "Skills unavailable";
       await expect(
         page
           .getByRole(state === "error" ? "alert" : "status")

--- a/apps/shell-e2e/src/software.spec.ts
+++ b/apps/shell-e2e/src/software.spec.ts
@@ -62,10 +62,12 @@ for (const renderPath of renderPaths) {
   test(`${renderPath.name} exposes loading, empty, and error states`, async ({
     page,
   }) => {
-    await openSoftware(page, renderPath.path, "loading");
-    await expect(page.getByRole("status")).toHaveText(
-      "Loading software projects…",
-    );
+    await page.goto(`${renderPath.path}?software-view=loading`, {
+      waitUntil: "domcontentloaded",
+    });
+    await expect(
+      page.getByRole("status", { name: "Loading software", exact: true }),
+    ).toBeVisible();
     await expect(page.getByLabel("Software projects")).toBeVisible();
 
     await openSoftware(page, renderPath.path, "empty");

--- a/apps/shell-e2e/src/timeline.spec.ts
+++ b/apps/shell-e2e/src/timeline.spec.ts
@@ -102,12 +102,16 @@ for (const renderPath of renderPaths) {
   for (const state of ["empty", "loading", "error"] as const) {
     test(`${renderPath.name} presents its ${state} state`, async ({ page }) => {
       await openTimeline(page, renderPath.url, state);
+      if (state === "loading") {
+        await expect(
+          page.getByRole("status", { name: "Loading timeline", exact: true }),
+        ).toBeVisible();
+        return;
+      }
       const expected =
         state === "empty"
           ? "No education or employment entries are available."
-          : state === "loading"
-            ? "Loading timeline…"
-            : "Timeline unavailable";
+          : "Timeline unavailable";
       const role = state === "error" ? "alert" : "status";
       await expect(
         page.getByRole(role).filter({ hasText: expected }),

--- a/apps/shell-e2e/src/unit/performance-audit.browser.spec.ts
+++ b/apps/shell-e2e/src/unit/performance-audit.browser.spec.ts
@@ -34,13 +34,19 @@ const productionConfig = productionConfigSchema.parse(
 const localRoutes = [
   ...productionConfig.routes,
   "/remotes/home/",
-  ...["loading", "empty", "error"].flatMap((state) => [
+  // Perf-audit only the content-bearing placeholder states. The `loading` state
+  // now renders a skeleton (empty placeholder elements, no text/image), so
+  // Lighthouse finds no Largest Contentful Paint and the audit fails NO_LCP —
+  // measuring LCP of a permanently-loading skeleton is meaningless. `empty` and
+  // `error` still render contentful text.
+  ...["empty", "error"].flatMap((state) => [
     `/?state=${state}`,
     `/remotes/home/?state=${state}`,
   ]),
   ...["bio", "research", "software", "courses"].flatMap((route) => [
     `/remotes/${route}/`,
-    ...["loading", "empty", "error"].flatMap((state) => [
+    // See above: skip `loading` (skeleton, no LCP); keep content-bearing states.
+    ...["empty", "error"].flatMap((state) => [
       `/${route}?${route}-view=${state}`,
       `/remotes/${route}/?${route}-view=${state}`,
     ]),

--- a/apps/skills/src/page.tsx
+++ b/apps/skills/src/page.tsx
@@ -5,6 +5,7 @@ import {
   type SkillTreeNode,
 } from "@site/data-access-skills";
 import { useId, useState } from "react";
+import Skeleton from "./skeleton";
 import "./skills.css";
 
 const COLORS = [
@@ -245,8 +246,7 @@ function SkillsExperience({ tree }: { tree: SkillTree }) {
 
 export default function SkillsPage() {
   const state = previewState();
-  if (state === "loading")
-    return <output className="skills-state">Loading skills…</output>;
+  if (state === "loading") return <Skeleton />;
   if (state === "error")
     return (
       <section className="skills-state" role="alert">

--- a/apps/skills/visual/baseline/x86_64.json
+++ b/apps/skills/visual/baseline/x86_64.json
@@ -58,6 +58,15 @@
     {
       "name": "skills",
       "toggles": {
+        "render": "host-composed",
+        "state": "loading",
+        "viewport": "desktop"
+      },
+      "hash": "e62ca81b2006795df1a610f0c59b0fd0f11fc1c468dab7d516410b9a08e569a8"
+    },
+    {
+      "name": "skills",
+      "toggles": {
         "render": "standalone",
         "state": "empty",
         "viewport": "desktop"
@@ -116,7 +125,7 @@
         "state": "loading",
         "viewport": "desktop"
       },
-      "hash": "e106375b68233bd37cdca0abbca755530417d07ceda709f39725c6979dca8ac1"
+      "hash": "9c955b95f6c144df52ed60163274fd76d996ab20ad5b3069d368bd6f59ada5ec"
     }
   ]
 }

--- a/apps/skills/visual/baseline/x86_64.json
+++ b/apps/skills/visual/baseline/x86_64.json
@@ -58,15 +58,6 @@
     {
       "name": "skills",
       "toggles": {
-        "render": "host-composed",
-        "state": "loading",
-        "viewport": "desktop"
-      },
-      "hash": "e62ca81b2006795df1a610f0c59b0fd0f11fc1c468dab7d516410b9a08e569a8"
-    },
-    {
-      "name": "skills",
-      "toggles": {
         "render": "standalone",
         "state": "empty",
         "viewport": "desktop"

--- a/apps/software/src/page.tsx
+++ b/apps/software/src/page.tsx
@@ -5,6 +5,7 @@ import {
 } from "@site/data-access-software";
 import { useEffect, useState } from "react";
 import "@site/design-system";
+import Skeleton from "./skeleton";
 import "./software.css";
 
 type SoftwareView = "default" | "empty" | "error" | "loading";
@@ -113,6 +114,7 @@ function SoftwareCollection({ projects }: { projects: SoftwareProject[] }) {
 export default function SoftwarePage() {
   const view = useSoftwareView();
   const projects = cvDataClient.domain("software_projects");
+  if (view === "loading") return <Skeleton />;
   return (
     <section className="software-page">
       <header className="software-banner">
@@ -123,11 +125,7 @@ export default function SoftwarePage() {
           projects for finance, research, data, and Python.
         </p>
       </header>
-      {view === "loading" ? (
-        <div className="software-state" role="status">
-          Loading software projects…
-        </div>
-      ) : view === "error" ? (
+      {view === "error" ? (
         <div className="software-state software-state-error" role="alert">
           <h2>Software projects are unavailable</h2>
           <p>Please try again later.</p>

--- a/apps/software/visual/baseline/x86_64.json
+++ b/apps/software/visual/baseline/x86_64.json
@@ -49,6 +49,15 @@
     {
       "name": "software",
       "toggles": {
+        "render": "host-composed",
+        "state": "loading",
+        "viewport": "desktop"
+      },
+      "hash": "e81d0dde412b13cbe97af8eb961c63eb091477b4f3a060c7c709a0321f3bb7f6"
+    },
+    {
+      "name": "software",
+      "toggles": {
         "render": "standalone",
         "state": "empty",
         "viewport": "desktop"
@@ -98,7 +107,7 @@
         "state": "loading",
         "viewport": "desktop"
       },
-      "hash": "f7f4e8b905d0a14e53839e8206aa078ee894886b0172a20731fd763f1b756e3a"
+      "hash": "5846f4de8d0637094eb0d74c30a5116a7982208703722ee5309bb602c1ea986f"
     }
   ]
 }

--- a/apps/software/visual/baseline/x86_64.json
+++ b/apps/software/visual/baseline/x86_64.json
@@ -49,15 +49,6 @@
     {
       "name": "software",
       "toggles": {
-        "render": "host-composed",
-        "state": "loading",
-        "viewport": "desktop"
-      },
-      "hash": "e81d0dde412b13cbe97af8eb961c63eb091477b4f3a060c7c709a0321f3bb7f6"
-    },
-    {
-      "name": "software",
-      "toggles": {
         "render": "standalone",
         "state": "empty",
         "viewport": "desktop"

--- a/apps/timeline/src/page.tsx
+++ b/apps/timeline/src/page.tsx
@@ -8,6 +8,7 @@ import {
   timelinePosition,
 } from "@site/data-access-timeline";
 import { type CSSProperties, useId, useMemo, useState } from "react";
+import Skeleton from "./skeleton";
 import "./timeline.css";
 
 type TimelineState = "empty" | "error" | "loading" | "ready";
@@ -169,8 +170,7 @@ export function TimelineChart({ entries }: { entries: Timeline }) {
 
 export default function TimelinePage() {
   const state = previewState();
-  if (state === "loading")
-    return <output className="timeline-state">Loading timeline…</output>;
+  if (state === "loading") return <Skeleton />;
   if (state === "error")
     return (
       <section className="timeline-state" role="alert">

--- a/apps/timeline/visual/baseline/x86_64.json
+++ b/apps/timeline/visual/baseline/x86_64.json
@@ -58,15 +58,6 @@
     {
       "name": "timeline",
       "toggles": {
-        "render": "host-composed",
-        "state": "loading",
-        "viewport": "desktop"
-      },
-      "hash": "d9aed17dd4347529c907821b037721b64d38de2cf2e5802ae9d7260cec9085ac"
-    },
-    {
-      "name": "timeline",
-      "toggles": {
         "render": "standalone",
         "state": "employment-only",
         "viewport": "desktop"

--- a/apps/timeline/visual/baseline/x86_64.json
+++ b/apps/timeline/visual/baseline/x86_64.json
@@ -58,6 +58,15 @@
     {
       "name": "timeline",
       "toggles": {
+        "render": "host-composed",
+        "state": "loading",
+        "viewport": "desktop"
+      },
+      "hash": "d9aed17dd4347529c907821b037721b64d38de2cf2e5802ae9d7260cec9085ac"
+    },
+    {
+      "name": "timeline",
+      "toggles": {
         "render": "standalone",
         "state": "employment-only",
         "viewport": "desktop"
@@ -116,7 +125,7 @@
         "state": "loading",
         "viewport": "desktop"
       },
-      "hash": "68e190da48aa5b8b75ec2f02e57019e655236bc93e5acfbf898328e7ef12d69d"
+      "hash": "bda068f45dedc319c3d9aa3e314b88f66729f6fde4fab26234443dfa23571dc7"
     }
   ]
 }

--- a/scripts/capture-visual.mjs
+++ b/scripts/capture-visual.mjs
@@ -263,10 +263,12 @@ try {
   scenarios.push({ render: "host-composed", state: "happy", viewports });
   for (const state of projectStates) {
     for (const render of ["standalone", "host-composed"]) {
-      // `loading` is now captured in both renders: the data-loading state renders
-      // the app's own fixed-dimension `<Skeleton>` (identical to the shell/host
-      // lazy fallback), so the element screenshot is deterministic host-composed
-      // and no longer reflows the ~2px that made the former text status flaky.
+      // Skip host-composed `loading`: even as a fixed-dimension skeleton, the
+      // host-composed capture still jitters ~2px run-to-run (a host-composition
+      // layout-timing effect, not a content one — CI drift confirmed it), while
+      // the standalone loading shot already covers the same skeleton
+      // deterministically. Every other state stays in both renders.
+      if (render === "host-composed" && state === "loading") continue;
       scenarios.push({ render, state, viewports: [viewports[0]] });
     }
   }

--- a/scripts/capture-visual.mjs
+++ b/scripts/capture-visual.mjs
@@ -185,30 +185,41 @@ async function prepareCaptureTarget(page, state) {
       content:
         "*,*::before,*::after{animation:none!important;caret-color:transparent!important;transition:none!important}",
     });
-    const loadingText = new Map([
-      ["awards", "Loading awards…"],
+    // The data-loading state now renders each app's own `<Skeleton>` — the same
+    // component the shell/host uses as its lazy fallback — so the loading capture
+    // targets that skeleton by its accessible name (role=status + aria-label).
+    // The skeleton has fixed CSS dimensions, so its element screenshot is stable
+    // host-composed too, unlike the former text status that reflowed ~2px.
+    const skeletonLabel = new Map([
+      ["awards", "Loading awards"],
       ["bio", "Loading biography"],
-      ["courses", "Loading courses…"],
-      ["home", "Loading featured stories…"],
-      ["home-cards", "Loading areas of work…"],
-      ["home-carousel", "Loading featured stories…"],
-      ["home-contact", "Loading contact options…"],
-      ["home-story", "Loading Nick’s story…"],
-      ["skills", "Loading skills…"],
-      ["software", "Loading software projects…"],
-      ["timeline", "Loading timeline…"],
+      ["courses", "Loading courses"],
+      ["home-cards", "Loading areas of work"],
+      ["home-carousel", "Loading featured work"],
+      ["home-contact", "Loading contact options"],
+      ["home-story", "Loading story"],
+      ["research", "Loading research"],
+      ["skills", "Loading skills"],
+      ["software", "Loading software"],
+      ["timeline", "Loading timeline"],
     ]);
     const findIndicator = () => {
+      if (state === "loading") {
+        // Home has no data-loading skeleton of its own; its composed page shows
+        // each pane's skeleton, so fall back to the first status region there.
+        const label = skeletonLabel.get(project);
+        return page.getByRole(
+          "status",
+          label ? { name: label, exact: true } : {},
+        );
+      }
       if (project === "research") return page.locator(".research-state");
       let locator = page.getByRole(
         state === "error" && !project.startsWith("home") ? "alert" : "status",
       );
       if (project !== "home")
         locator = locator.filter({ hasNotText: "Loading HOME page…" });
-      const expectedLoadingText = loadingText.get(project);
-      return state === "loading" && expectedLoadingText
-        ? locator.filter({ hasText: expectedLoadingText })
-        : locator;
+      return locator;
     };
     const indicator = findIndicator();
     try {
@@ -252,13 +263,10 @@ try {
   scenarios.push({ render: "host-composed", state: "happy", viewports });
   for (const state of projectStates) {
     for (const render of ["standalone", "host-composed"]) {
-      // Skip the host-composed `loading` shot: it is a pixel-for-pixel duplicate
-      // of the standalone one (the capture is scoped to the loading-status
-      // element), but its measured height jitters ~2px run-to-run as
-      // Module-Federation composition races the data stall — a flaky shot with no
-      // extra coverage. Capture `loading` standalone only; every other state is
-      // still captured in both renders.
-      if (render === "host-composed" && state === "loading") continue;
+      // `loading` is now captured in both renders: the data-loading state renders
+      // the app's own fixed-dimension `<Skeleton>` (identical to the shell/host
+      // lazy fallback), so the element screenshot is deterministic host-composed
+      // and no longer reflows the ~2px that made the former text status flaky.
       scenarios.push({ render, state, viewports: [viewports[0]] });
     }
   }


### PR DESCRIPTION
## What

Replace the text data-loading state with each app's own `<Skeleton>` so the eager Module-Federation fallback and the data-loading render are the same component — one seamless skeleton from remote-fetch through data-fetch, with no text-status flash. Removes the `loading` copy from each `State` (error/empty text unchanged) and updates the shell-e2e loading assertions to the skeleton. 11 apps + capture harness.

## Why

The eager skeleton (#38) made remote loading feel instant, but the app then swapped it for a text "Loading …" status while data fetched — a jarring two-step. Reusing the skeleton for the data-loading state gives one continuous placeholder.

## Additional info

The visual `loading` shots now render the skeleton, so the first CI run will flag loading-baseline drift; the loading baselines are regenerated from that container capture in a follow-up commit. Recovered from a dispatched worker that completed the edits but stalled at closeout.