### PR TITLE
feat(ci-tools): add a reviewed Linux aarch64 platform contract

### DIFF
--- a/apps/shell-e2e/src/unit/ci-tools-contract.spec.ts
+++ b/apps/shell-e2e/src/unit/ci-tools-contract.spec.ts
@@ -42,6 +42,7 @@ function temporaryDirectory(prefix: string) {
 
 // A `uname` ahead of the real one on PATH, so a single host can exercise every
 // reviewed platform and a rejected one.
+// llmlint: ignore-block[e2e_not_mocked] The host CPU is the one input a single machine cannot vary, and the installer under test is never mocked: it is the real script reading a real `uname` process, and the specs below drive its real download, checksum, and install path unmocked on this host's own architecture.
 function hostPath(system: string, machine: string) {
   const directory = temporaryDirectory("ci-tools-host.");
   const shim = path.join(directory, "uname");
@@ -52,6 +53,7 @@ function hostPath(system: string, machine: string) {
   );
   return `${directory}:${process.env.PATH ?? ""}`;
 }
+// llmlint: ignore-end[e2e_not_mocked]
 
 function runOnHost(system: string, machine: string, args: string[]) {
   return spawnSync(script, args, {
@@ -137,6 +139,19 @@ describe("pinned CI tool platform contract", () => {
     expect(result.stdout).toBe("");
   });
 
+  it.each([["--install"], ["--verify --plan"], ["--plan extra"]])(
+    "rejects the unsupported invocation %s",
+    (invocation) => {
+      const result = runInWorkingDirectory(workspace, invocation.split(" "));
+
+      expect(result.status).toBe(2);
+      expect(result.stderr).toContain(
+        "unsupported arguments; usage: setup-ci-tools.sh [--verify|--plan]",
+      );
+      expect(result.stdout).toBe("");
+    },
+  );
+
   it("provisions checksum-verified tools on this host and reports the pins", () => {
     const directory = contractWorkspace(() => {});
 
@@ -161,6 +176,8 @@ describe("pinned CI tool platform contract", () => {
 
   it("installs nothing when a pinned digest does not match the upstream archive", () => {
     const directory = contractWorkspace((parsed) => {
+      // The tampered document is deliberately written back unvalidated, so this
+      // narrows the parsed JSON rather than reusing the contract schema.
       const actionlint = parsed.actionlint as {
         sha256: Record<string, string>;
       };

--- a/apps/shell-e2e/src/unit/ci-tools-contract.spec.ts
+++ b/apps/shell-e2e/src/unit/ci-tools-contract.spec.ts
@@ -1,0 +1,239 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+
+// The reviewed platform contract for the pinned workflow and shell linters.
+// `.tools/` provisioning is checksum-verified on every supported host, so these
+// specs drive the real installer: its architecture selection, its contract
+// validator, and — on this host's own architecture — a real download, checksum
+// check, and install.
+
+const workspace = path.resolve(import.meta.dirname, "../../../..");
+const script = path.join(workspace, "scripts/setup-ci-tools.sh");
+const digestSchema = z.object({
+  x86_64: z.string().regex(/^[0-9a-f]{64}$/),
+  aarch64: z.string().regex(/^[0-9a-f]{64}$/),
+});
+const contractSchema = z.object({
+  schema: z.literal(3),
+  actionlint: z.object({
+    version: z.string().regex(/^\d+\.\d+\.\d+$/),
+    sha256: digestSchema,
+  }),
+  shellcheck: z.object({
+    version: z.string().regex(/^\d+\.\d+\.\d+$/),
+    sha256: digestSchema,
+  }),
+});
+const contractPath = path.join(workspace, "ci-tools.json");
+const contract = contractSchema.parse(
+  JSON.parse(readFileSync(contractPath, "utf8")),
+);
+const temporaryDirectories: string[] = [];
+
+function temporaryDirectory(prefix: string) {
+  const directory = mkdtempSync(path.join(tmpdir(), prefix));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+// A `uname` ahead of the real one on PATH, so a single host can exercise every
+// reviewed platform and a rejected one.
+function hostPath(system: string, machine: string) {
+  const directory = temporaryDirectory("ci-tools-host.");
+  const shim = path.join(directory, "uname");
+  writeFileSync(
+    shim,
+    `#!/bin/sh\ncase "$1" in\n  -s) echo "${system}" ;;\n  -m) echo "${machine}" ;;\n  *) exit 1 ;;\nesac\n`,
+    { mode: 0o755 },
+  );
+  return `${directory}:${process.env.PATH ?? ""}`;
+}
+
+function runOnHost(system: string, machine: string, args: string[]) {
+  return spawnSync(script, args, {
+    cwd: workspace,
+    encoding: "utf8",
+    env: { ...process.env, PATH: hostPath(system, machine) },
+  });
+}
+
+function runInWorkingDirectory(directory: string, args: string[]) {
+  return spawnSync(script, args, {
+    cwd: directory,
+    encoding: "utf8",
+  });
+}
+
+// A workspace holding only the pinned contract, so provisioning writes its
+// `.tools/` beneath a disposable root.
+function contractWorkspace(
+  overrides: (parsed: Record<string, unknown>) => void,
+) {
+  const directory = temporaryDirectory("ci-tools-contract.");
+  const parsed = JSON.parse(readFileSync(contractPath, "utf8"));
+  overrides(parsed);
+  writeFileSync(
+    path.join(directory, "ci-tools.json"),
+    JSON.stringify(parsed, null, 2),
+  );
+  return directory;
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    execFileSync("rm", ["-rf", directory]);
+  }
+});
+
+describe("pinned CI tool platform contract", () => {
+  it("selects the amd64/x86_64 upstream archives on Linux x86_64", () => {
+    const result = runOnHost("Linux", "x86_64", ["--plan"]);
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toBe(
+      [
+        "platform x86_64",
+        `actionlint https://github.com/rhysd/actionlint/releases/download/v${contract.actionlint.version}/actionlint_${contract.actionlint.version}_linux_amd64.tar.gz ${contract.actionlint.sha256.x86_64}`,
+        `shellcheck https://github.com/koalaman/shellcheck/releases/download/v${contract.shellcheck.version}/shellcheck-v${contract.shellcheck.version}.linux.x86_64.tar.gz ${contract.shellcheck.sha256.x86_64}`,
+        "",
+      ].join("\n"),
+    );
+  });
+
+  // actionlint and shellcheck spell the same 64-bit Arm architecture
+  // differently, and `uname -m` itself reports either spelling.
+  it.each(["aarch64", "arm64"])(
+    "selects the arm64/aarch64 upstream archives on Linux %s",
+    (machine) => {
+      const result = runOnHost("Linux", machine, ["--plan"]);
+
+      expect(result.status, result.stderr).toBe(0);
+      expect(result.stdout).toBe(
+        [
+          "platform aarch64",
+          `actionlint https://github.com/rhysd/actionlint/releases/download/v${contract.actionlint.version}/actionlint_${contract.actionlint.version}_linux_arm64.tar.gz ${contract.actionlint.sha256.aarch64}`,
+          `shellcheck https://github.com/koalaman/shellcheck/releases/download/v${contract.shellcheck.version}/shellcheck-v${contract.shellcheck.version}.linux.aarch64.tar.gz ${contract.shellcheck.sha256.aarch64}`,
+          "",
+        ].join("\n"),
+      );
+    },
+  );
+
+  it.each([
+    ["Linux", "ppc64le"],
+    ["Linux", "i686"],
+    ["Darwin", "arm64"],
+  ])("refuses to provision on unsupported %s %s", (system, machine) => {
+    const result = runOnHost(system, machine, []);
+
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain(
+      "pinned binaries support Linux x86_64 and Linux aarch64",
+    );
+    expect(result.stdout).toBe("");
+  });
+
+  it("provisions checksum-verified tools on this host and reports the pins", () => {
+    const directory = contractWorkspace(() => {});
+
+    const install = runInWorkingDirectory(directory, []);
+    expect(install.status, install.stderr).toBe(0);
+
+    const verify = runInWorkingDirectory(directory, ["--verify"]);
+    expect(verify.status, verify.stderr).toBe(0);
+    expect(verify.stdout).toBe(
+      `actionlint ${contract.actionlint.version}, shellcheck ${contract.shellcheck.version}\n`,
+    );
+    expect(
+      execFileSync(
+        path.join(directory, ".tools/bin/shellcheck"),
+        ["--version"],
+        {
+          encoding: "utf8",
+        },
+      ),
+    ).toContain(`version: ${contract.shellcheck.version}`);
+  }, 180_000);
+
+  it("installs nothing when a pinned digest does not match the upstream archive", () => {
+    const directory = contractWorkspace((parsed) => {
+      const actionlint = parsed.actionlint as {
+        sha256: Record<string, string>;
+      };
+      for (const platform of Object.keys(actionlint.sha256))
+        actionlint.sha256[platform] = "0".repeat(64);
+    });
+
+    const result = runInWorkingDirectory(directory, []);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      "actionlint archive checksum mismatch; verify ci-tools.json against the upstream release",
+    );
+    expect(existsSync(path.join(directory, ".tools/bin/actionlint"))).toBe(
+      false,
+    );
+    expect(existsSync(path.join(directory, ".tools/bin/shellcheck"))).toBe(
+      false,
+    );
+  }, 180_000);
+});
+
+describe("ci-tools.json contract validation", () => {
+  it.each([
+    [
+      "a malformed document",
+      "{ not json",
+      "ci-tools.json failed contract validation",
+    ],
+    [
+      // The schema 2 shape carried a single amd64-only digest per tool.
+      "the previous single-platform schema",
+      JSON.stringify({
+        schema: 2,
+        actionlint: {
+          version: contract.actionlint.version,
+          sha256: contract.actionlint.sha256.x86_64,
+        },
+        shellcheck: {
+          version: contract.shellcheck.version,
+          sha256: contract.shellcheck.sha256.x86_64,
+        },
+        codex: JSON.parse(readFileSync(contractPath, "utf8")).codex,
+      }),
+      "restore ci-tools.json schema 3",
+    ],
+    [
+      "a tool missing a supported platform digest",
+      JSON.stringify({
+        ...JSON.parse(readFileSync(contractPath, "utf8")),
+        shellcheck: {
+          version: contract.shellcheck.version,
+          sha256: { x86_64: contract.shellcheck.sha256.x86_64 },
+        },
+      }),
+      "invalid shellcheck contract; pin a sha256 for exactly these platforms",
+    ],
+    [
+      "an unpinned codex release",
+      JSON.stringify({
+        ...JSON.parse(readFileSync(contractPath, "utf8")),
+        codex: { package: "@openai/codex", version: "0.145.0", integrity: "" },
+      }),
+      "invalid codex contract",
+    ],
+  ])("rejects %s", (_, document, message) => {
+    const directory = temporaryDirectory("ci-tools-invalid.");
+    writeFileSync(path.join(directory, "ci-tools.json"), document);
+
+    const result = runInWorkingDirectory(directory, ["--verify"]);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(message);
+    expect(result.stdout).toBe("");
+  });
+});

--- a/ci-tools.json
+++ b/ci-tools.json
@@ -1,12 +1,18 @@
 {
-  "schema": 2,
+  "schema": 3,
   "actionlint": {
     "version": "1.7.12",
-    "sha256": "8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8"
+    "sha256": {
+      "x86_64": "8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8",
+      "aarch64": "325e971b6ba9bfa504672e29be93c24981eeb1c07576d730e9f7c8805afff0c6"
+    }
   },
   "shellcheck": {
     "version": "0.11.0",
-    "sha256": "b7af85e41cc99489dcc21d66c6d5f3685138f06d34651e6d34b42ec6d54fe6f6"
+    "sha256": {
+      "x86_64": "b7af85e41cc99489dcc21d66c6d5f3685138f06d34651e6d34b42ec6d54fe6f6",
+      "aarch64": "68a8133197a50beb8803f8d42f9908d1af1c5540d4bb05fdfca8c1fa47decefc"
+    }
   },
   "codex": {
     "package": "@openai/codex",

--- a/scripts/setup-ci-tools.sh
+++ b/scripts/setup-ci-tools.sh
@@ -3,24 +3,41 @@
 set -euo pipefail
 tool_root="$(pwd)/.tools"
 tool_bin="$tool_root/bin"
+# Reviewed platform contract. Each supported host maps to the upstream archive
+# tokens for its architecture: actionlint publishes Go's amd64/arm64 spelling
+# while shellcheck publishes x86_64/aarch64, and both ship every supported
+# Linux architecture as .tar.gz, so no extra decompressor is required.
+case "$(uname -s) $(uname -m)" in
+  "Linux x86_64") platform="x86_64" actionlint_arch="amd64" shellcheck_arch="x86_64" ;;
+  "Linux aarch64" | "Linux arm64") platform="aarch64" actionlint_arch="arm64" shellcheck_arch="aarch64" ;;
+  *) platform="" actionlint_arch="" shellcheck_arch="" ;;
+esac
 read_contract() {
   node -e '
     const contract = require("./ci-tools.json");
     const keys = ["schema", "actionlint", "shellcheck", "codex"];
-    if (!contract || Object.keys(contract).length !== keys.length || !keys.every((key) => Object.hasOwn(contract, key)) || contract.schema !== 2) throw new Error("invalid CI tool contract; restore ci-tools.json schema 2 with exactly the actionlint, shellcheck, and codex pins");
+    if (!contract || Object.keys(contract).length !== keys.length || !keys.every((key) => Object.hasOwn(contract, key)) || contract.schema !== 3) throw new Error("invalid CI tool contract; restore ci-tools.json schema 3 with exactly the actionlint, shellcheck, and codex pins");
+    const platforms = ["x86_64", "aarch64"];
     for (const name of ["actionlint", "shellcheck"]) {
       const tool = contract[name];
-      if (!tool || Object.keys(tool).length !== 2 || !/^\d+\.\d+\.\d+$/.test(tool.version) || !/^[0-9a-f]{64}$/.test(tool.sha256)) throw new Error("invalid " + name + " contract");
+      if (!tool || Object.keys(tool).length !== 2 || !/^\d+\.\d+\.\d+$/.test(tool.version)) throw new Error("invalid " + name + " contract");
+      const digests = tool.sha256;
+      if (!digests || Object.keys(digests).length !== platforms.length || !platforms.every((key) => /^[0-9a-f]{64}$/.test(digests[key]))) throw new Error("invalid " + name + " contract; pin a sha256 for exactly these platforms: " + platforms.join(", "));
     }
     const codex = contract.codex;
     if (!codex || Object.keys(codex).length !== 3 || codex.package !== "@openai/codex" || !/^\d+\.\d+\.\d+$/.test(codex.version) || !/^sha512-[A-Za-z0-9+/]+={0,2}$/.test(codex.integrity)) throw new Error("invalid codex contract; update ci-tools.json with the exact @openai/codex npm version and sha512 integrity");
-    process.stdout.write([contract.actionlint.version, contract.actionlint.sha256, contract.shellcheck.version, contract.shellcheck.sha256].join("\n"));
-  '
+    const platform = process.argv[1];
+    process.stdout.write([contract.actionlint.version, contract.shellcheck.version, contract.actionlint.sha256[platform] ?? "", contract.shellcheck.sha256[platform] ?? ""].join("\n"));
+  ' "$platform"
 }
-mapfile -t contract < <(read_contract)
+contract_report=$(read_contract) || {
+  echo "setup-ci-tools: ci-tools.json failed contract validation; restore the pinned tool contract reported above, then rerun just bootstrap" >&2
+  exit 1
+}
+mapfile -t contract <<<"$contract_report"
 actionlint_version="${contract[0]:-}"
-actionlint_sha="${contract[1]:-}"
-shellcheck_version="${contract[2]:-}"
+shellcheck_version="${contract[1]:-}"
+actionlint_sha="${contract[2]:-}"
 shellcheck_sha="${contract[3]:-}"
 verify_tools() {
   [[ -x "$tool_bin/actionlint" && -x "$tool_bin/shellcheck" ]] || return 1
@@ -33,10 +50,20 @@ if [[ "${1:-}" == "--verify" ]]; then
   printf 'actionlint %s, shellcheck %s\n' "$actionlint_version" "$shellcheck_version"
   exit 0
 fi
-[[ "$(uname -s)" == "Linux" && "$(uname -m)" == "x86_64" ]] || {
-  echo "setup-ci-tools: pinned binaries support Linux x86_64; use the repository CI container or add a reviewed platform contract" >&2
+[[ -n "$platform" ]] || {
+  echo "setup-ci-tools: pinned binaries support Linux x86_64 and Linux aarch64; use the repository CI container or add a reviewed platform contract" >&2
   exit 2
 }
+actionlint_archive="actionlint_${actionlint_version}_linux_${actionlint_arch}.tar.gz"
+actionlint_url="https://github.com/rhysd/actionlint/releases/download/v${actionlint_version}/${actionlint_archive}"
+shellcheck_archive="shellcheck-v${shellcheck_version}.linux.${shellcheck_arch}.tar.gz"
+shellcheck_url="https://github.com/koalaman/shellcheck/releases/download/v${shellcheck_version}/${shellcheck_archive}"
+# The archives and digests this host would install, so the reviewed platform
+# contract is observable without downloading anything.
+if [[ "${1:-}" == "--plan" ]]; then
+  printf 'platform %s\nactionlint %s %s\nshellcheck %s %s\n' "$platform" "$actionlint_url" "$actionlint_sha" "$shellcheck_url" "$shellcheck_sha"
+  exit 0
+fi
 if verify_tools; then exit 0; fi
 provisioning_failed() {
   local setup_status=$?
@@ -47,16 +74,14 @@ trap provisioning_failed ERR
 mkdir -p "$tool_bin"
 setup_tmp=$(mktemp -d)
 trap 'rm -rf "$setup_tmp"' EXIT
-actionlint_archive="actionlint_${actionlint_version}_linux_amd64.tar.gz"
-curl -fsSL "https://github.com/rhysd/actionlint/releases/download/v${actionlint_version}/${actionlint_archive}" -o "$setup_tmp/$actionlint_archive"
+curl -fsSL "$actionlint_url" -o "$setup_tmp/$actionlint_archive"
 printf '%s  %s\n' "$actionlint_sha" "$setup_tmp/$actionlint_archive" | sha256sum --check --status || {
   echo "setup-ci-tools: actionlint archive checksum mismatch; verify ci-tools.json against the upstream release" >&2
   exit 1
 }
 tar -xzf "$setup_tmp/$actionlint_archive" -C "$setup_tmp" actionlint
 install -m 0755 "$setup_tmp/actionlint" "$tool_bin/actionlint"
-shellcheck_archive="shellcheck-v${shellcheck_version}.linux.x86_64.tar.gz"
-curl -fsSL "https://github.com/koalaman/shellcheck/releases/download/v${shellcheck_version}/${shellcheck_archive}" -o "$setup_tmp/$shellcheck_archive"
+curl -fsSL "$shellcheck_url" -o "$setup_tmp/$shellcheck_archive"
 printf '%s  %s\n' "$shellcheck_sha" "$setup_tmp/$shellcheck_archive" | sha256sum --check --status || {
   echo "setup-ci-tools: shellcheck archive checksum mismatch; verify ci-tools.json against the upstream release" >&2
   exit 1

--- a/scripts/setup-ci-tools.sh
+++ b/scripts/setup-ci-tools.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 # llmlint: ignore-file[changed_behavior_has_e2e] This CI/developer installer has no browser interface; its checksum and executable verification paths exercise the real downloaded tools.
 set -euo pipefail
+mode="${1:-}"
+[[ $# -le 1 && ("$mode" == "" || "$mode" == "--verify" || "$mode" == "--plan") ]] || {
+  echo "setup-ci-tools: unsupported arguments; usage: setup-ci-tools.sh [--verify|--plan]" >&2
+  exit 2
+}
 tool_root="$(pwd)/.tools"
 tool_bin="$tool_root/bin"
 # Reviewed platform contract. Each supported host maps to the upstream archive
@@ -45,7 +50,7 @@ verify_tools() {
   [[ "${actionlint_report%%$'\n'*}" == "$actionlint_version" ]] || return 1
   "$tool_bin/shellcheck" --version | grep -Fx "version: $shellcheck_version" >/dev/null
 }
-if [[ "${1:-}" == "--verify" ]]; then
+if [[ "$mode" == "--verify" ]]; then
   verify_tools || { echo "setup-ci-tools: pinned actionlint and shellcheck are not provisioned; run just bootstrap" >&2; exit 1; }
   printf 'actionlint %s, shellcheck %s\n' "$actionlint_version" "$shellcheck_version"
   exit 0
@@ -60,7 +65,8 @@ shellcheck_archive="shellcheck-v${shellcheck_version}.linux.${shellcheck_arch}.t
 shellcheck_url="https://github.com/koalaman/shellcheck/releases/download/v${shellcheck_version}/${shellcheck_archive}"
 # The archives and digests this host would install, so the reviewed platform
 # contract is observable without downloading anything.
-if [[ "${1:-}" == "--plan" ]]; then
+if [[ "$mode" == "--plan" ]]; then
+  # llmlint: ignore[tool_output_is_signal] This report mode exists only to emit the resolved platform contract; each line is a distinct pinned artifact, so the report is the signal rather than progress narration.
   printf 'platform %s\nactionlint %s %s\nshellcheck %s %s\n' "$platform" "$actionlint_url" "$actionlint_sha" "$shellcheck_url" "$shellcheck_sha"
   exit 0
 fi


### PR DESCRIPTION
## What

`just bootstrap` now provisions checksum-verified `actionlint` and `shellcheck`
on Linux aarch64 as well as Linux x86_64, so the full `just check` gate runs on
either architecture. The pinned contract in `ci-tools.json` carries a verified
digest per supported platform, and the installer picks the upstream archive and
digest from the host architecture. Linux x86_64 is untouched: same versions,
same archives, same bytes, same `--verify` output. Any other host still fails
with a message naming the supported platforms — there is no fallback to an
unverified download or a system-installed binary. New specs run the real
installer to cover contract validation and architecture selection across both
supported platforms and a rejected one.

## Why

The repository owner develops on a Linux aarch64 machine, where the installer
hard-failed and took `just bootstrap` and the whole pre-push gate down with it
— `lint-workflows` cannot run without these two binaries. Everything else in
the gate already worked natively on that host, so this was the single thing
blocking local verification of any change. The installer's own error message
named a reviewed platform contract as the remedy; this adds one.
