### PR TITLE
feat: make hover intent fully preload home panes and software images

### DIFF
--- a/.github/workflows/visual-docs.yml
+++ b/.github/workflows/visual-docs.yml
@@ -101,13 +101,21 @@ jobs:
       # Each affected app is built (with the composed shell + home remotes its
       # host-composed shots need, via the Nx screenshot target's dependsOn) and
       # captured to $SHOTS_OUT. Runs twice for screencomp's reproducibility gate.
+      # POSIX sh only. The reusable workflow injects this string into `run:` with
+      # no `shell:` key, so it runs under the container's /bin/sh (dash), where
+      # `[[ ... =~ ... ]]` is not a builtin: it exits 127, takes the failure
+      # branch, and reports every project name as invalid. The three patterns
+      # below spell out the old ^[a-z][a-z0-9-]*$ — empty, a first character that
+      # is not a lowercase letter, or any later character outside [a-z0-9-].
       capture-command: |
         corepack enable
         pnpm install --frozen-lockfile
-        [[ "$SCREENCOMP_PROJECT" =~ ^[a-z][a-z0-9-]*$ ]] || {
-          echo "capture-command: SCREENCOMP_PROJECT must be a valid Nx project name" >&2
-          exit 2
-        }
+        case "$SCREENCOMP_PROJECT" in
+          "" | [!a-z]* | [a-z]*[!a-z0-9-]*)
+            echo "capture-command: SCREENCOMP_PROJECT must be a valid Nx project name" >&2
+            exit 2
+            ;;
+        esac
         pnpm exec nx run "$SCREENCOMP_PROJECT:screenshot"
     secrets:
       # llmlint: ignore[boundary_inputs_validated] The pinned reusable workflow's pages-preflight job rejects a missing token before any consumer or external write; GitHub masks the secret and owns token syntax/authorization validation.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,7 @@ cache locking or a remote cache.
 
 This numbered inventory is the browser-test contract; extend it with every new route, feature, or state.
 
-1. Site shell: all five Pages-base routes load directly with header, footer, route content, and no failed assets; keyboard navigation works; each route retains useful substantive prerendered HTML without JavaScript; unknown paths show the static 404 recovery document and client-side redirect home; `/story` redirects to `/bio`.
+1. Site shell: all five Pages-base routes load directly with header, footer, route content, and no failed assets; keyboard navigation works; each route retains useful substantive prerendered HTML without JavaScript; unknown paths show the static 404 recovery document and client-side redirect home; `/story` redirects to `/bio`; hover intent preloads a route's code, data, and images, so a settled hover then click mounts Home's panes and Software's warm card logos without a skeleton, while a click that beats the preload still shows skeletons and settles.
 2. Federation ownership: all 12 remotes render without failed assets through both standalone and host-composed boundaries.
 3. Home: its composed page and carousel, cards, story, contact, timeline, skills, and awards panes cover happy, empty, loading, and error states in both render paths; action links, automatic and keyboard carousel controls, responsive breakpoints, and invalid build-script inputs are covered.
 4. Bio: complete story, responsive layout, and happy, empty, loading, and error states in both render paths.

--- a/apps/awards/src/page.tsx
+++ b/apps/awards/src/page.tsx
@@ -5,8 +5,12 @@ import {
 } from "@site/data-access-awards";
 import { AwardEmblem } from "./award-emblem";
 import Skeleton from "./skeleton";
-import { useAwards } from "./use-awards";
+import { preloadAwards, useAwards } from "./use-awards";
 import "./awards.css";
+
+// Hosts reach this through the remote's existing ./Page expose, so warming the
+// pane costs no new federation surface.
+export { preloadAwards as preload };
 
 function State({ name }: { name: "error" | "empty" }) {
   const copy =

--- a/apps/awards/src/use-awards.ts
+++ b/apps/awards/src/use-awards.ts
@@ -7,10 +7,21 @@ export type AwardsViewState =
   | { name: "ready"; awards: Awards };
 const scenarios = new Set(["empty", "error", "loading"]);
 
-// Warmed awards keyed by the exact request URL, so a preview scenario never
-// resolves from the data warmed for the default view, or the other way round.
-const warmedAwards = new Map<string, Awards>();
+/**
+ * One awards request per URL, so a host that warms the pane and the pane's own
+ * mount share a single fetch rather than racing two. `value` is the settled
+ * response kept only so the first render can read it synchronously; nothing but
+ * the fetch below ever writes here, and a rejected request drops itself so the
+ * next mount retries.
+ */
+interface AwardsRequest {
+  promise: Promise<Awards>;
+  value?: Awards;
+}
+const awardsRequests = new Map<string, AwardsRequest>();
 
+// Keying by the exact request URL keeps a preview scenario from resolving out
+// of the response warmed for the default view, or the other way round.
 function awardsRequestUrl(): URL {
   const url = new URL(
     "/nick-derobertis-site/cv-data/domains/awards.json",
@@ -24,59 +35,68 @@ function awardsRequestUrl(): URL {
   return url;
 }
 
-async function requestAwards(url: URL, signal?: AbortSignal): Promise<Awards> {
-  const response = await fetch(url, signal ? { signal } : {});
-  if (!response.ok)
-    throw new Error(`Awards request failed: ${response.status}`);
-  return validateCvDomain("awards", await response.json());
+function awardsRequest(url: URL): AwardsRequest {
+  const existing = awardsRequests.get(url.href);
+  if (existing) return existing;
+  const request: AwardsRequest = {
+    promise: (async () => {
+      const response = await fetch(url);
+      if (!response.ok)
+        throw new Error(`Awards request failed: ${response.status}`);
+      return validateCvDomain("awards", await response.json());
+    })().then(
+      (awards) => {
+        request.value = awards;
+        return awards;
+      },
+      (error: unknown) => {
+        awardsRequests.delete(url.href);
+        throw error;
+      },
+    ),
+  };
+  awardsRequests.set(url.href, request);
+  return request;
 }
 
 /**
  * Fetches the awards this pane needs ahead of its first render, so a host that
  * preloads the pane can mount it ready instead of on its loading skeleton. A
- * failed warm is deliberately swallowed: the pane's own request still runs and
- * owns the error state, so a warm that fails changes nothing a visitor sees.
+ * failed warm is deliberately swallowed: it drops itself from the cache, the
+ * pane's own request runs on mount, and that request owns the error state.
  */
 export async function preloadAwards(): Promise<void> {
   if (typeof window === "undefined") return;
-  const url = awardsRequestUrl();
-  if (warmedAwards.has(url.href)) return;
   try {
-    warmedAwards.set(url.href, await requestAwards(url));
+    await awardsRequest(awardsRequestUrl()).promise;
   } catch {
     return;
   }
 }
 
 export function useAwards(): AwardsViewState {
-  // Seeding from the warm cache during the initial render is what removes the
+  // Reading a settled request during the initial render is what removes the
   // loading frame. Server rendering never warms, so its markup is unchanged.
   const [state, setState] = useState<AwardsViewState>(() => {
     if (typeof window === "undefined") return { name: "loading" };
-    const warmed = warmedAwards.get(awardsRequestUrl().href);
+    const warmed = awardsRequests.get(awardsRequestUrl().href)?.value;
     return warmed ? { name: "ready", awards: warmed } : { name: "loading" };
   });
   useEffect(() => {
-    const url = awardsRequestUrl();
-    // A warm that lands between this render and this effect still has to reach
-    // the pane; skipping the request without adopting it would strand the pane
-    // on its skeleton forever.
-    const warmed = warmedAwards.get(url.href);
-    if (warmed) {
-      setState((current) =>
-        current.name === "ready" ? current : { name: "ready", awards: warmed },
-      );
-      return;
-    }
-    const controller = new AbortController();
-    requestAwards(url, controller.signal).then(
-      (awards) => setState({ name: "ready", awards }),
-      (error: unknown) => {
-        if (!(error instanceof DOMException && error.name === "AbortError"))
-          setState({ name: "error" });
+    // The request is shared, so an unmount stops listening rather than
+    // aborting it out from under whoever else is waiting on the same URL.
+    let listening = true;
+    awardsRequest(awardsRequestUrl()).promise.then(
+      (awards) => {
+        if (listening) setState({ name: "ready", awards });
+      },
+      () => {
+        if (listening) setState({ name: "error" });
       },
     );
-    return () => controller.abort();
+    return () => {
+      listening = false;
+    };
   }, []);
   return state;
 }

--- a/apps/awards/src/use-awards.ts
+++ b/apps/awards/src/use-awards.ts
@@ -14,6 +14,7 @@ const scenarios = new Set(["empty", "error", "loading"]);
  * the fetch below ever writes here, and a rejected request drops itself so the
  * next mount retries.
  */
+// llmlint: ignore-block[server_state_not_duplicated_in_global_store] This map is the pane's data-fetching layer, not a copy alongside one: the site ships no query client, and a cache that outlives the component is the only place a host preload can deposit a response the pane has not mounted to request yet. Entries are immutable per URL, written solely by the fetch below, and never mutated by rendering.
 interface AwardsRequest {
   promise: Promise<Awards>;
   value?: Awards;
@@ -58,6 +59,7 @@ function awardsRequest(url: URL): AwardsRequest {
   awardsRequests.set(url.href, request);
   return request;
 }
+// llmlint: ignore-end[server_state_not_duplicated_in_global_store]
 
 /**
  * Fetches the awards this pane needs ahead of its first render, so a host that
@@ -65,6 +67,7 @@ function awardsRequest(url: URL): AwardsRequest {
  * failed warm is deliberately swallowed: it drops itself from the cache, the
  * pane's own request runs on mount, and that request owns the error state.
  */
+// llmlint: ignore[changed_behavior_has_e2e] Only a host calls this, so there is no standalone trigger to drive: awards.spec.ts already covers the standalone remote's happy, empty, and error paths, and every one of them now runs through the shared request below. preload.spec.ts covers the warmed and unavailable host paths.
 export async function preloadAwards(): Promise<void> {
   if (typeof window === "undefined") return;
   try {

--- a/apps/awards/src/use-awards.ts
+++ b/apps/awards/src/use-awards.ts
@@ -7,32 +7,75 @@ export type AwardsViewState =
   | { name: "ready"; awards: Awards };
 const scenarios = new Set(["empty", "error", "loading"]);
 
+// Warmed awards keyed by the exact request URL, so a preview scenario never
+// resolves from the data warmed for the default view, or the other way round.
+const warmedAwards = new Map<string, Awards>();
+
+function awardsRequestUrl(): URL {
+  const url = new URL(
+    "/nick-derobertis-site/cv-data/domains/awards.json",
+    window.location.origin,
+  );
+  const scenario = new URLSearchParams(window.location.search).get(
+    "awards-scenario",
+  );
+  if (scenario && scenarios.has(scenario))
+    url.searchParams.set("scenario", scenario);
+  return url;
+}
+
+async function requestAwards(url: URL, signal?: AbortSignal): Promise<Awards> {
+  const response = await fetch(url, signal ? { signal } : {});
+  if (!response.ok)
+    throw new Error(`Awards request failed: ${response.status}`);
+  return validateCvDomain("awards", await response.json());
+}
+
+/**
+ * Fetches the awards this pane needs ahead of its first render, so a host that
+ * preloads the pane can mount it ready instead of on its loading skeleton. A
+ * failed warm is deliberately swallowed: the pane's own request still runs and
+ * owns the error state, so a warm that fails changes nothing a visitor sees.
+ */
+export async function preloadAwards(): Promise<void> {
+  if (typeof window === "undefined") return;
+  const url = awardsRequestUrl();
+  if (warmedAwards.has(url.href)) return;
+  try {
+    warmedAwards.set(url.href, await requestAwards(url));
+  } catch {
+    return;
+  }
+}
+
 export function useAwards(): AwardsViewState {
-  const [state, setState] = useState<AwardsViewState>({ name: "loading" });
+  // Seeding from the warm cache during the initial render is what removes the
+  // loading frame. Server rendering never warms, so its markup is unchanged.
+  const [state, setState] = useState<AwardsViewState>(() => {
+    if (typeof window === "undefined") return { name: "loading" };
+    const warmed = warmedAwards.get(awardsRequestUrl().href);
+    return warmed ? { name: "ready", awards: warmed } : { name: "loading" };
+  });
   useEffect(() => {
-    const controller = new AbortController();
-    const url = new URL(
-      "/nick-derobertis-site/cv-data/domains/awards.json",
-      window.location.origin,
-    );
-    const scenario = new URLSearchParams(window.location.search).get(
-      "awards-scenario",
-    );
-    if (scenario && scenarios.has(scenario))
-      url.searchParams.set("scenario", scenario);
-    fetch(url, { signal: controller.signal })
-      .then(async (response) => {
-        if (!response.ok)
-          throw new Error(`Awards request failed: ${response.status}`);
-        return validateCvDomain("awards", await response.json());
-      })
-      .then(
-        (awards) => setState({ name: "ready", awards }),
-        (error: unknown) => {
-          if (!(error instanceof DOMException && error.name === "AbortError"))
-            setState({ name: "error" });
-        },
+    const url = awardsRequestUrl();
+    // A warm that lands between this render and this effect still has to reach
+    // the pane; skipping the request without adopting it would strand the pane
+    // on its skeleton forever.
+    const warmed = warmedAwards.get(url.href);
+    if (warmed) {
+      setState((current) =>
+        current.name === "ready" ? current : { name: "ready", awards: warmed },
       );
+      return;
+    }
+    const controller = new AbortController();
+    requestAwards(url, controller.signal).then(
+      (awards) => setState({ name: "ready", awards }),
+      (error: unknown) => {
+        if (!(error instanceof DOMException && error.name === "AbortError"))
+          setState({ name: "error" });
+      },
+    );
     return () => controller.abort();
   }, []);
   return state;

--- a/apps/home/src/page.tsx
+++ b/apps/home/src/page.tsx
@@ -6,7 +6,7 @@ import { siteBase } from "@site/data-access-core";
 import { homeContent } from "@site/data-access-home";
 import { prerenderRouteAttribute } from "@site/route-state";
 import AwardsSkeleton from "awards/Skeleton";
-import { type ComponentType, lazy, Suspense } from "react";
+import { type ComponentType, lazy, Suspense, useState } from "react";
 import SkillsSkeleton from "skills/Skeleton";
 import TimelineSkeleton from "timeline/Skeleton";
 import "./home.css";
@@ -46,7 +46,8 @@ type HydratedPanes = [
   ComponentType,
 ];
 let hydratedPanes: HydratedPanes | undefined;
-if (hydrateFromSource) {
+
+async function resolvePanes(): Promise<HydratedPanes> {
   const [carousel, cards, story, skills, awards, contact, timeline] =
     await Promise.all([
       carouselModule,
@@ -57,7 +58,7 @@ if (hydrateFromSource) {
       contactModule,
       timelineModule,
     ]);
-  hydratedPanes = [
+  return [
     carousel.default,
     cards.default,
     story.default,
@@ -68,12 +69,32 @@ if (hydrateFromSource) {
   ];
 }
 
+if (hydrateFromSource) hydratedPanes = await resolvePanes();
+
+let panePreload: Promise<void> | undefined;
+
+// The shell's Home route loader calls this on hover intent, generalizing the
+// entry-at-"/" pane cache to client-side navigation: once it settles, Home
+// mounts the resolved panes directly instead of suspending on lazy() — which
+// flashes a skeleton on first mount even when its promise already resolved.
+// Server rendering composes the panes directly, so there is nothing to warm.
+export function preload(): Promise<void> {
+  if (typeof document === "undefined") return Promise.resolve();
+  panePreload ??= resolvePanes().then((panes) => {
+    hydratedPanes = panes;
+  });
+  return panePreload;
+}
+
 // Keep the Home host in both shared data dependency graphs; panes own rendering.
 void siteBase;
 void homeContent;
 
 export default function HomePage() {
-  if (hydratedPanes) {
+  // Settle the render path once per mount: a preload that lands mid-life must
+  // not swap pane component identity and remount every pane underneath.
+  const [panes] = useState(() => hydratedPanes);
+  if (panes) {
     const [
       HydratedCarousel,
       HydratedCards,
@@ -82,7 +103,7 @@ export default function HomePage() {
       HydratedAwards,
       HydratedContact,
       HydratedTimeline,
-    ] = hydratedPanes;
+    ] = panes;
     return (
       <div className="home-main">
         <HydratedCarousel />

--- a/apps/home/src/page.tsx
+++ b/apps/home/src/page.tsx
@@ -89,6 +89,7 @@ let panePreload: Promise<void> | undefined;
 // mounts the resolved panes directly instead of suspending on lazy() — which
 // flashes a skeleton on first mount even when its promise already resolved.
 // Server rendering composes the panes directly, so there is nothing to warm.
+// llmlint: ignore[changed_behavior_has_e2e] Hover intent is a shell-router behaviour, so this entry point has no standalone equivalent to cover: apps/home/src/main.tsx mounts the page with no router and no nav links to hover. preload.spec.ts drives it through the real shell, and home.spec.ts keeps covering the standalone remote's render path, which still takes the Suspense branch below.
 export function preload(): Promise<void> {
   if (typeof document === "undefined") return Promise.resolve();
   panePreload ??= (async () => {

--- a/apps/home/src/page.tsx
+++ b/apps/home/src/page.tsx
@@ -71,6 +71,17 @@ async function resolvePanes(): Promise<HydratedPanes> {
 
 if (hydrateFromSource) hydratedPanes = await resolvePanes();
 
+// Panes own their data. Carousel, cards, story and contact read bundled
+// homeContent, and timeline and skills read bundled CV domains, so all six
+// render their content on the first frame. Awards is the one pane that fetches,
+// so warming it is what lets a preloaded Home mount with no skeleton anywhere.
+// The entry-at-"/" path deliberately does not warm: its prerendered markup
+// contains the awards skeleton, and seeding past it would break hydration.
+async function warmPaneData(): Promise<void> {
+  const awards = await awardsModule;
+  await awards.preload();
+}
+
 let panePreload: Promise<void> | undefined;
 
 // The shell's Home route loader calls this on hover intent, generalizing the
@@ -80,9 +91,10 @@ let panePreload: Promise<void> | undefined;
 // Server rendering composes the panes directly, so there is nothing to warm.
 export function preload(): Promise<void> {
   if (typeof document === "undefined") return Promise.resolve();
-  panePreload ??= resolvePanes().then((panes) => {
+  panePreload ??= (async () => {
+    const [panes] = await Promise.all([resolvePanes(), warmPaneData()]);
     hydratedPanes = panes;
-  });
+  })();
   return panePreload;
 }
 

--- a/apps/home/src/remotes.d.ts
+++ b/apps/home/src/remotes.d.ts
@@ -42,5 +42,7 @@ declare module "awards/Page" {
   import type { ComponentType } from "react";
 
   const Page: ComponentType;
+  // Fetches the pane's awards so a warmed Home mounts it past its skeleton.
+  export function preload(): Promise<void>;
   export default Page;
 }

--- a/apps/shell-e2e/src/preload.spec.ts
+++ b/apps/shell-e2e/src/preload.spec.ts
@@ -1,23 +1,27 @@
 import { readFileSync } from "node:fs";
 import { expect, type Page, test } from "@playwright/test";
+import { z } from "zod";
 
 // llmlint: ignore-block[tests_mirror_real_usage] "Hover a link, then click, and the switch is instant" is only observable through request and DOM-mutation instrumentation, because a warm arrival is defined by requests that never repeat and skeletons that never appear. Every navigation still uses the real header links with real hover and click input.
 
-interface SoftwareLogoProject {
-  logo_base64?: string;
-  logo_url?: string;
-}
-
+const softwareLogoProjects = z
+  .array(
+    z.object({
+      logo_base64: z.string().optional(),
+      logo_url: z.url().optional(),
+    }),
+  )
+  .parse(
+    JSON.parse(
+      readFileSync(
+        "libs/data-access-core/vendor/codegen/domains/software_projects.json",
+        "utf8",
+      ),
+    ),
+  );
 // Cards prefer an inline logo_base64, so only these URLs cost a request. One
 // card per external URL is rendered; the URLs themselves repeat across cards.
-const softwareLogoSources = (
-  JSON.parse(
-    readFileSync(
-      "libs/data-access-core/vendor/codegen/domains/software_projects.json",
-      "utf8",
-    ),
-  ) as SoftwareLogoProject[]
-).flatMap((project) =>
+const softwareLogoSources = softwareLogoProjects.flatMap((project) =>
   project.logo_base64 || !project.logo_url ? [] : [project.logo_url],
 );
 const softwareLogoUrls = [...new Set(softwareLogoSources)];
@@ -62,12 +66,14 @@ async function holdCarouselPane(page: Page) {
   const held = new Promise<void>((resolve) => {
     release = resolve;
   });
+  // llmlint: ignore-block[e2e_not_mocked,changed_behavior_has_e2e] Nothing is stubbed here: the real remote chunk is fetched from the real server and served back byte for byte, and only its arrival time moves. Deferring it is the only way to reproduce "the visitor clicked before the preload settled", which is otherwise a millisecond-wide race against a local server.
   await page.route("**/remotes/home-carousel/*.js", async (route) => {
     const response = await route.fetch();
     const body = await response.text();
     if (body.includes("Next featured story")) await held;
     await route.fulfill({ response, body });
   });
+  // llmlint: ignore-end[e2e_not_mocked,changed_behavior_has_e2e]
   return () => release();
 }
 
@@ -82,6 +88,7 @@ declare global {
  * so a test can assert one never appeared rather than sampling for it.
  */
 async function recordStatusRoles(page: Page) {
+  // llmlint: ignore-block[e2e_uses_accessible_selectors] This observer matches on the accessible status role itself and reports each skeleton by its accessible name. Playwright locators sample the DOM as it is now, so they cannot answer "did a skeleton ever appear" — only a live MutationObserver can.
   await page.evaluate(() => {
     const seen: string[] = [];
     window.__statusRoles = seen;
@@ -101,6 +108,7 @@ async function recordStatusRoles(page: Page) {
         for (const node of record.addedNodes) collect(node);
     }).observe(document.body, { childList: true, subtree: true });
   });
+  // llmlint: ignore-end[e2e_uses_accessible_selectors]
   return () => page.evaluate(() => window.__statusRoles ?? []);
 }
 
@@ -119,6 +127,28 @@ async function openBio(page: Page) {
 
 const navLink = (page: Page, label: string) =>
   page.getByRole("link", { name: label, exact: true });
+
+/**
+ * Reports the card logos loaded from a URL, as the visitor's DOM shows them:
+ * `sourced` counts the images the browser has settled on a URL for, `painted`
+ * counts those that decoded. Inline logo_base64 cards are excluded, since they
+ * never cost a request and a warmed cache cannot change anything about them.
+ */
+async function countUrlLogoImages(page: Page) {
+  const images = await Promise.all(
+    (await page.getByRole("img").all()).map((logo) =>
+      logo.evaluate((image: HTMLImageElement) => ({
+        fromUrl: image.currentSrc.startsWith("http"),
+        painted: image.complete && image.naturalWidth > 0,
+      })),
+    ),
+  );
+  const fromUrl = images.filter((image) => image.fromUrl);
+  return {
+    painted: fromUrl.filter((image) => image.painted).length,
+    sourced: fromUrl.length,
+  };
+}
 
 test("hovering Software preloads its domain data and every card logo", async ({
   page,
@@ -165,24 +195,10 @@ test("clicking Software after its preload settles renders warm, skeleton-free ca
   for (const logo of await page.getByRole("img").all())
     await logo.scrollIntoViewIfNeeded();
   await expect
-    .poll(() =>
-      page.evaluate(() =>
-        [...document.querySelectorAll<HTMLImageElement>("img.software-logo")]
-          .filter((image) => image.currentSrc.startsWith("http"))
-          .reduce(
-            (totals, image) => ({
-              painted:
-                totals.painted +
-                (image.complete && image.naturalWidth > 0 ? 1 : 0),
-              requested: totals.requested + 1,
-            }),
-            { painted: 0, requested: 0 },
-          ),
-      ),
-    )
+    .poll(() => countUrlLogoImages(page))
     .toEqual({
       painted: softwareLogoSources.length,
-      requested: softwareLogoSources.length,
+      sourced: softwareLogoSources.length,
     });
   expect(failedLogoRequests).toEqual([]);
   expect(logoRequests).toHaveLength(warmedRequests);

--- a/apps/shell-e2e/src/preload.spec.ts
+++ b/apps/shell-e2e/src/preload.spec.ts
@@ -238,7 +238,7 @@ test("clicking Home after its preload settles mounts every pane without a skelet
 test("clicking Home recovers when the warmed awards data is unavailable", async ({
   page,
 }) => {
-  // llmlint: ignore-block[e2e_not_mocked] Nothing about the app is stubbed: this makes the awards endpoint answer 503, the real upstream failure the pane's error state exists for. No query-string scenario can reach it, because a client-side navigation to "/" drops the search the awards pane reads.
+  // llmlint: ignore-block[e2e_not_mocked,changed_behavior_has_e2e] Nothing about the app is stubbed: this makes the awards endpoint answer 503, the real upstream failure the pane's error state exists for, and every other part of the journey is the real shell reached through real hover and click. The e2e provider's `?awards-scenario=error` cannot reach this path, because a client-side navigation to "/" drops the search the awards pane reads.
   await page.route("**/cv-data/domains/awards.json*", (route) =>
     route.fulfill({
       status: 503,
@@ -246,7 +246,7 @@ test("clicking Home recovers when the warmed awards data is unavailable", async 
       body: JSON.stringify({ error: "awards unavailable" }),
     }),
   );
-  // llmlint: ignore-end[e2e_not_mocked]
+  // llmlint: ignore-end[e2e_not_mocked,changed_behavior_has_e2e]
   await openBio(page);
   await navLink(page, "Home").hover();
   await page.waitForLoadState("networkidle");

--- a/apps/shell-e2e/src/preload.spec.ts
+++ b/apps/shell-e2e/src/preload.spec.ts
@@ -1,0 +1,242 @@
+import { readFileSync } from "node:fs";
+import { expect, type Page, test } from "@playwright/test";
+
+// llmlint: ignore-block[tests_mirror_real_usage] "Hover a link, then click, and the switch is instant" is only observable through request and DOM-mutation instrumentation, because a warm arrival is defined by requests that never repeat and skeletons that never appear. Every navigation still uses the real header links with real hover and click input.
+
+interface SoftwareLogoProject {
+  logo_base64?: string;
+  logo_url?: string;
+}
+
+// Cards prefer an inline logo_base64, so only these URLs cost a request. One
+// card per external URL is rendered; the URLs themselves repeat across cards.
+const softwareLogoSources = (
+  JSON.parse(
+    readFileSync(
+      "libs/data-access-core/vendor/codegen/domains/software_projects.json",
+      "utf8",
+    ),
+  ) as SoftwareLogoProject[]
+).flatMap((project) =>
+  project.logo_base64 || !project.logo_url ? [] : [project.logo_url],
+);
+const softwareLogoUrls = [...new Set(softwareLogoSources)];
+if (softwareLogoUrls.length === 0)
+  throw new Error(
+    "software_projects.json must ship external logo_url values for the preload journey; regenerate the vendored CV data and rerun just test-e2e",
+  );
+
+/**
+ * Records the software route's own traffic. These journeys deliberately do not
+ * route or stub the logo hosts: Playwright's request routing disables the HTTP
+ * cache, and serving the click from that cache is the point of warming it.
+ */
+function recordSoftwareTraffic(page: Page) {
+  const logoUrls = new Set(softwareLogoUrls);
+  const logoRequests: string[] = [];
+  const logoResponses: string[] = [];
+  const failedLogoRequests: string[] = [];
+  const domainRequests: string[] = [];
+  page.on("request", (request) => {
+    if (logoUrls.has(request.url())) logoRequests.push(request.url());
+    else if (request.url().includes("/cv-data/domains/software_projects.json"))
+      domainRequests.push(request.url());
+  });
+  page.on("response", (response) => {
+    if (logoUrls.has(response.url()) && response.ok())
+      logoResponses.push(response.url());
+  });
+  page.on("requestfailed", (request) => {
+    if (logoUrls.has(request.url())) failedLogoRequests.push(request.url());
+  });
+  return { domainRequests, failedLogoRequests, logoRequests, logoResponses };
+}
+
+/**
+ * Holds back the chunk carrying the carousel pane until the returned release is
+ * called, so a click can land before Home's preload has settled. Its Skeleton
+ * ships in a different chunk and stays available as the Suspense fallback.
+ */
+async function holdCarouselPane(page: Page) {
+  let release = () => {};
+  const held = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  await page.route("**/remotes/home-carousel/*.js", async (route) => {
+    const response = await route.fetch();
+    const body = await response.text();
+    if (body.includes("Next featured story")) await held;
+    await route.fulfill({ response, body });
+  });
+  return () => release();
+}
+
+declare global {
+  interface Window {
+    __statusRoles?: string[];
+  }
+}
+
+/**
+ * Records every `role="status"` skeleton that reaches the document from now on,
+ * so a test can assert one never appeared rather than sampling for it.
+ */
+async function recordStatusRoles(page: Page) {
+  await page.evaluate(() => {
+    const seen: string[] = [];
+    window.__statusRoles = seen;
+    const collect = (node: Node) => {
+      if (!(node instanceof Element)) return;
+      for (const status of [
+        ...(node.matches('[role="status"]') ? [node] : []),
+        ...node.querySelectorAll('[role="status"]'),
+      ])
+        seen.push(
+          status.getAttribute("aria-label") ?? status.textContent ?? "",
+        );
+    };
+    collect(document.body);
+    new MutationObserver((records) => {
+      for (const record of records)
+        for (const node of record.addedNodes) collect(node);
+    }).observe(document.body, { childList: true, subtree: true });
+  });
+  return () => page.evaluate(() => window.__statusRoles ?? []);
+}
+
+/**
+ * Enters Bio through the /story redirect. Arriving at /bio by client-side
+ * redirect proves the router owns the document, so a later hover exercises
+ * route preloading instead of racing hydration.
+ */
+async function openBio(page: Page) {
+  await page.goto("story", { waitUntil: "domcontentloaded" });
+  await expect(page).toHaveURL(/\/bio$/);
+  await expect(
+    page.getByRole("heading", { name: "Optimizing Life" }),
+  ).toBeVisible();
+}
+
+const navLink = (page: Page, label: string) =>
+  page.getByRole("link", { name: label, exact: true });
+
+test("hovering Software preloads its domain data and every card logo", async ({
+  page,
+}) => {
+  const { domainRequests, logoRequests } = recordSoftwareTraffic(page);
+  await openBio(page);
+  expect(domainRequests).toEqual([]);
+  expect(logoRequests).toEqual([]);
+
+  await navLink(page, "Software").hover();
+
+  await expect
+    .poll(() => [...logoRequests].sort())
+    .toEqual([...softwareLogoUrls].sort());
+  expect(domainRequests).toHaveLength(1);
+  await expect(
+    page.getByRole("heading", { name: "Open-Source Software" }),
+  ).toHaveCount(0);
+});
+
+test("clicking Software after its preload settles renders warm, skeleton-free cards", async ({
+  page,
+}) => {
+  const { failedLogoRequests, logoRequests, logoResponses } =
+    recordSoftwareTraffic(page);
+  await openBio(page);
+  await navLink(page, "Software").hover();
+  await expect.poll(() => logoResponses.length).toBe(softwareLogoUrls.length);
+  const warmedRequests = logoRequests.length;
+  const statusRoles = await recordStatusRoles(page);
+
+  await navLink(page, "Software").click();
+
+  await expect(
+    page.getByRole("heading", { name: "Open-Source Software" }),
+  ).toBeVisible();
+  await expect(
+    page.getByLabel("Software projects").getByRole("article"),
+  ).toHaveCount(72);
+  expect(await statusRoles()).toEqual([]);
+
+  // Browsing the grid the way a visitor would paints every external logo from
+  // the warmed cache; none of them costs a request after the click.
+  for (const logo of await page.getByRole("img").all())
+    await logo.scrollIntoViewIfNeeded();
+  await expect
+    .poll(() =>
+      page.evaluate(() =>
+        [...document.querySelectorAll<HTMLImageElement>("img.software-logo")]
+          .filter((image) => image.currentSrc.startsWith("http"))
+          .reduce(
+            (totals, image) => ({
+              painted:
+                totals.painted +
+                (image.complete && image.naturalWidth > 0 ? 1 : 0),
+              requested: totals.requested + 1,
+            }),
+            { painted: 0, requested: 0 },
+          ),
+      ),
+    )
+    .toEqual({
+      painted: softwareLogoSources.length,
+      requested: softwareLogoSources.length,
+    });
+  expect(failedLogoRequests).toEqual([]);
+  expect(logoRequests).toHaveLength(warmedRequests);
+});
+
+test("clicking Home after its preload settles mounts every pane without a skeleton", async ({
+  page,
+}) => {
+  await openBio(page);
+  await navLink(page, "Home").hover();
+  await page.waitForLoadState("networkidle");
+  const statusRoles = await recordStatusRoles(page);
+
+  await navLink(page, "Home").click();
+
+  await expect(
+    page.getByRole("region", { name: "Featured work" }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("region", { name: "Areas of work" }),
+  ).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Who am I?" })).toBeVisible();
+  await expect(
+    page.getByRole("heading", { name: "Let’s build something useful." }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("region", { name: "Timeline visualization" }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("heading", { name: "Selected awards" }),
+  ).toBeVisible();
+  // Every pane arrives fully rendered because its module preload settled. The
+  // awards pane still mounts in its own loading state because it owns a
+  // client-side data fetch, which module preloading cannot resolve for it.
+  expect(await statusRoles()).toEqual(["Loading awards"]);
+});
+
+test("clicking Home before its preload settles still shows pane skeletons", async ({
+  page,
+}) => {
+  const releaseCarouselPane = await holdCarouselPane(page);
+  await openBio(page);
+
+  await navLink(page, "Home").click();
+
+  await expect(
+    page.getByRole("status", { name: "Loading featured work", exact: true }),
+  ).toBeVisible();
+
+  releaseCarouselPane();
+
+  await expect(
+    page.getByRole("region", { name: "Featured work" }),
+  ).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Who am I?" })).toBeVisible();
+});
+// llmlint: ignore-end[tests_mirror_real_usage]

--- a/apps/shell-e2e/src/preload.spec.ts
+++ b/apps/shell-e2e/src/preload.spec.ts
@@ -230,10 +230,40 @@ test("clicking Home after its preload settles mounts every pane without a skelet
   await expect(
     page.getByRole("heading", { name: "Selected awards" }),
   ).toBeVisible();
-  // Every pane arrives fully rendered because its module preload settled. The
-  // awards pane still mounts in its own loading state because it owns a
-  // client-side data fetch, which module preloading cannot resolve for it.
-  expect(await statusRoles()).toEqual(["Loading awards"]);
+  // All seven panes arrive fully rendered: their modules and the one pane that
+  // fetches its own data were both warmed, so no skeleton mounts at all.
+  expect(await statusRoles()).toEqual([]);
+});
+
+test("clicking Home recovers when the warmed awards data is unavailable", async ({
+  page,
+}) => {
+  // llmlint: ignore-block[e2e_not_mocked] Nothing about the app is stubbed: this makes the awards endpoint answer 503, the real upstream failure the pane's error state exists for. No query-string scenario can reach it, because a client-side navigation to "/" drops the search the awards pane reads.
+  await page.route("**/cv-data/domains/awards.json*", (route) =>
+    route.fulfill({
+      status: 503,
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ error: "awards unavailable" }),
+    }),
+  );
+  // llmlint: ignore-end[e2e_not_mocked]
+  await openBio(page);
+  await navLink(page, "Home").hover();
+  await page.waitForLoadState("networkidle");
+
+  await navLink(page, "Home").click();
+
+  await expect(
+    page.getByRole("alert").filter({ hasText: "Awards unavailable" }),
+  ).toBeVisible();
+  // A pane that cannot warm must not hold back the six that need no data.
+  await expect(
+    page.getByRole("region", { name: "Featured work" }),
+  ).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Who am I?" })).toBeVisible();
+  await expect(
+    page.getByRole("region", { name: "Timeline visualization" }),
+  ).toBeVisible();
 });
 
 test("clicking Home before its preload settles still shows pane skeletons", async ({

--- a/apps/shell-e2e/src/unit/federation-contract.spec.ts
+++ b/apps/shell-e2e/src/unit/federation-contract.spec.ts
@@ -22,6 +22,17 @@ const awardsContract = [
   ["libs/build-config/src/remotes.json", '"awards": "awards"'],
 ] as const;
 
+// The shell declares home/Page ambiently, so the remote's preload export, the
+// host's declaration of it, and the router wiring have to move together. The
+// `as const` narrows the entries to the readonly path/expected tuples
+// expectContract takes, the same way every contract above does.
+const homePreloadContract = [
+  ["apps/home/src/page.tsx", "export function preload(): Promise<void>"],
+  ["apps/shell/src/remotes.d.ts", "export function preload(): Promise<void>;"],
+  ["apps/shell/src/main.tsx", "homePreload: home.preload"],
+  ["apps/shell/src/router.tsx", "homePreload?: () => Promise<void>"],
+] as const;
+
 const bioContract = [
   ["apps/bio/src/page.tsx", 'id="bio-heading">Optimizing Life'],
   ["apps/shell-e2e/src/bio.spec.ts", 'name: "Optimizing Life"'],
@@ -53,6 +64,12 @@ describe("timeline federation contract", () => {
 describe("awards federation contract", () => {
   it("keeps every required Nx, host, and federation declaration in sync", async () => {
     await expectContract(awardsContract);
+  });
+});
+
+describe("home preload federation contract", () => {
+  it("keeps the remote export, host declaration, and router wiring in sync", async () => {
+    await expectContract(homePreloadContract);
   });
 });
 

--- a/apps/shell-e2e/src/unit/federation-contract.spec.ts
+++ b/apps/shell-e2e/src/unit/federation-contract.spec.ts
@@ -31,6 +31,10 @@ const homePreloadContract = [
   ["apps/shell/src/remotes.d.ts", "export function preload(): Promise<void>;"],
   ["apps/shell/src/main.tsx", "homePreload: home.preload"],
   ["apps/shell/src/router.tsx", "homePreload?: () => Promise<void>"],
+  ["apps/awards/src/page.tsx", "export { preloadAwards as preload }"],
+  ["apps/awards/src/use-awards.ts", "export async function preloadAwards()"],
+  ["apps/home/src/remotes.d.ts", "export function preload(): Promise<void>;"],
+  ["apps/home/src/page.tsx", "await awards.preload()"],
 ] as const;
 
 const bioContract = [

--- a/apps/shell/src/main.tsx
+++ b/apps/shell/src/main.tsx
@@ -18,6 +18,7 @@ const router = createSiteRouter({
   history: createBrowserHistory(),
   pages: {
     home: home.default,
+    homePreload: home.preload,
     bio: bio.default,
     research: research.default,
     software: software.default,

--- a/apps/shell/src/remotes.d.ts
+++ b/apps/shell/src/remotes.d.ts
@@ -4,6 +4,8 @@ declare module "home/Page" {
   import type { ComponentType } from "react";
 
   const Page: ComponentType<Record<string, unknown>>;
+  // Resolves Home's pane modules so a hovered Home link mounts them directly.
+  export function preload(): Promise<void>;
   export default Page;
 }
 declare module "bio/Page" {

--- a/apps/shell/src/router.tsx
+++ b/apps/shell/src/router.tsx
@@ -30,6 +30,11 @@ import { routes } from "./routes";
 
 export interface RoutePages {
   home: ComponentType;
+  /**
+   * Resolves Home's pane modules so a hovered Home link mounts them without a
+   * skeleton. Server rendering composes the panes directly and omits it.
+   */
+  homePreload?: () => Promise<void>;
   bio: ComponentType<BioPageProps>;
   research: ComponentType<ResearchPageProps<Research>>;
   software: ComponentType<SoftwarePageProps<SoftwareProjects>>;
@@ -41,6 +46,24 @@ interface RouterContext {
   loadDomain(name: "software_projects"): Promise<SoftwareProjects>;
   loadDomain(name: "courses"): Promise<Courses>;
   search: URLSearchParams;
+}
+
+// Warmed logos are kept alive here so the browser cannot collect an in-flight
+// request, and so a repeated loader run never refetches an already warm URL.
+const warmedSoftwareLogos = new Map<string, HTMLImageElement>();
+
+// Software cards render `logo_base64` in preference to `logo_url`, so only the
+// external URLs cost a request. Warming them alongside the domain JSON means a
+// hovered Software link arrives with its visible card logos already decoded.
+function warmSoftwareLogos(projects: SoftwareProjects) {
+  if (typeof Image === "undefined") return;
+  for (const project of projects) {
+    const url = project.logo_base64 ? undefined : project.logo_url;
+    if (!url || warmedSoftwareLogos.has(url)) continue;
+    const image = new Image();
+    warmedSoftwareLogos.set(url, image);
+    image.src = url;
+  }
 }
 
 const routePath = (label: string) => {
@@ -71,6 +94,12 @@ export function createSiteRouter({
   const home = createRoute({
     getParentRoute: () => Root,
     path: routePath("Home"),
+    // Start the pane preload without awaiting it: hover intent gets a warm
+    // Home, while a click that lands first still mounts the pane skeletons
+    // immediately instead of stalling on the previous route.
+    loader: () => {
+      void pages.homePreload?.();
+    },
     component: () => <pages.home />,
   });
   const bio = createRoute({
@@ -124,10 +153,9 @@ export function createSiteRouter({
       if (view === "loading" || view === "error")
         return { projects: null, view };
       try {
-        return {
-          projects: await ctx.loadDomain("software_projects"),
-          view,
-        };
+        const projects = await ctx.loadDomain("software_projects");
+        warmSoftwareLogos(projects);
+        return { projects, view };
       } catch {
         return { projects: null, view: "error" as const };
       }

--- a/apps/shell/src/router.tsx
+++ b/apps/shell/src/router.tsx
@@ -157,6 +157,9 @@ export function createSiteRouter({
         warmSoftwareLogos(projects);
         return { projects, view };
       } catch {
+        // `as const` keeps this branch's view a literal; without it the union
+        // with the branches above widens to string and the page loses the
+        // narrowing it renders from.
         return { projects: null, view: "error" as const };
       }
     },

--- a/justfile
+++ b/justfile
@@ -25,6 +25,9 @@ lint-workflows:
     scripts/setup-ci-tools.sh --verify >/dev/null
     .tools/bin/actionlint .github/workflows/*.yml || { echo "lint-workflows: GitHub workflow validation failed; fix the actionlint findings above, then rerun just lint-workflows" >&2; exit 1; }
     .tools/bin/shellcheck scripts/*.sh .githooks/pre-push || { echo "lint-workflows: shell validation failed; fix the shellcheck findings above, then rerun just lint-workflows" >&2; exit 1; }
+    # screencomp runs its injected capture callback with the container's /bin/sh,
+    # and actionlint only shellchecks literal run: blocks, so check them as POSIX sh here.
+    callbacks=$(mktemp -d); trap 'rm -rf "$callbacks"' EXIT; node scripts/extract-injected-callbacks.mjs "$callbacks" && .tools/bin/shellcheck --shell=sh "$callbacks"/*.sh || { echo "lint-workflows: screencomp's injected capture callback is not valid POSIX sh; rewrite it without bash-only constructs, then rerun just lint-workflows" >&2; exit 1; }
     node scripts/verify-visual-contract.mjs || { echo "lint-workflows: visual tool pins or capture contracts drifted; update visual-tools.json and every named consumer together" >&2; exit 1; }
     node scripts/verify-reference-migration.mjs || { echo "lint-workflows: PR #12 reference migration verification failed; repair the migration map or its owned baselines and retry" >&2; exit 1; }
 

--- a/scripts/extract-injected-callbacks.mjs
+++ b/scripts/extract-injected-callbacks.mjs
@@ -1,0 +1,67 @@
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+// llmlint: ignore-file[changed_behavior_has_e2e] This CLI/filesystem extractor has no browser interface; lint-workflows executes its real boundary against the committed workflow and hands the result to shellcheck.
+
+// screencomp's reusable workflow injects these strings into a `run:` step that
+// declares no `shell:`, so the container's /bin/sh (dash) executes them. A
+// bash-only construct there does not fail loudly: it exits 127, takes the
+// failure branch, and reports a bogus domain error that reads as visual drift.
+// actionlint shellchecks literal `run:` blocks only, so a callback passed
+// through `with:` reaches CI unlinted unless it is extracted and checked here.
+const workflowPath = ".github/workflows/visual-docs.yml";
+const injectedCallbacks = ["capture-command"];
+
+process.on("uncaughtException", (error) => {
+  console.error(
+    `extract-injected-callbacks: ${error instanceof Error ? error.message : String(error)}; repair ${workflowPath} and rerun just lint-workflows`,
+  );
+  process.exit(1);
+});
+
+const [outputDirectory] = process.argv.slice(2);
+if (typeof outputDirectory !== "string" || outputDirectory.length === 0)
+  throw new Error(
+    "an output directory argument is required, for example just lint-workflows",
+  );
+
+function extractBlockScalar(lines, key) {
+  const start = lines.findIndex((line) =>
+    new RegExp(`^\\s*${key}:\\s*\\|\\s*$`).test(line),
+  );
+  if (start === -1)
+    throw new Error(
+      `${workflowPath} must pass ${key} to the screencomp reusable workflow as a literal block scalar`,
+    );
+  const keyIndent = /^\s*/.exec(lines[start])[0].length;
+  const bodyIndent = /^\s*/.exec(lines[start + 1] ?? "")[0];
+  if (bodyIndent.length <= keyIndent)
+    throw new Error(
+      `${workflowPath} ${key} block is empty; restore the callback`,
+    );
+  const body = [];
+  for (const line of lines.slice(start + 1)) {
+    if (line.trim() === "") {
+      body.push("");
+      continue;
+    }
+    if (!line.startsWith(bodyIndent)) break;
+    body.push(line.slice(bodyIndent.length));
+  }
+  return `${body.join("\n").trimEnd()}\n`;
+}
+
+const lines = readFileSync(workflowPath, "utf8").split("\n");
+mkdirSync(outputDirectory, { recursive: true });
+for (const key of injectedCallbacks) {
+  // GitHub expands `${{ … }}` before the shell ever sees it, so a placeholder
+  // keeps shellcheck parsing the shell rather than the expression syntax.
+  const callback = extractBlockScalar(lines, key).replaceAll(
+    /\$\{\{[^}]*\}\}/g,
+    "expression",
+  );
+  writeFileSync(join(outputDirectory, `${key}.sh`), callback);
+}
+console.log(
+  `extracted ${injectedCallbacks.length} injected screencomp callback(s) from ${workflowPath}`,
+);

--- a/scripts/verify-visual-contract.mjs
+++ b/scripts/verify-visual-contract.mjs
@@ -1,7 +1,4 @@
-import { spawnSync } from "node:child_process";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { readFileSync } from "node:fs";
 
 // llmlint: ignore-file[changed_behavior_has_e2e] This CLI/filesystem quality-gate validator has no browser interface; lint-workflows executes its real boundary against committed workflow, configuration, baselines, and documentation.
 
@@ -49,67 +46,6 @@ const sources = [
   ],
 ];
 const captureSource = readFileSync("scripts/capture-visual.mjs", "utf8");
-
-// screencomp's reusable workflow injects these callbacks into a `run:` step with
-// no `shell:` key, so the container's /bin/sh (dash) runs them — a bash-only
-// construct there does not fail loudly, it takes the `||` branch and reports a
-// bogus domain error, which reads as visual drift in classify-gate. actionlint
-// only shellchecks literal `run:` blocks, so these strings reach CI unlinted
-// unless this gate checks them as POSIX sh.
-const injectedShellCallbacks = ["capture-command"];
-function extractBlockScalar(source, key) {
-  const lines = source.split("\n");
-  const start = lines.findIndex((line) =>
-    new RegExp(`^\\s*${key}:\\s*\\|\\s*$`).test(line),
-  );
-  if (start === -1)
-    throw new Error(
-      `.github/workflows/visual-docs.yml must pass ${key} to the screencomp reusable workflow as a literal block scalar`,
-    );
-  const body = [];
-  const indent = /^\s*/.exec(lines[start + 1] ?? "")[0];
-  if (indent.length <= /^\s*/.exec(lines[start])[0].length)
-    throw new Error(
-      `.github/workflows/visual-docs.yml ${key} block is empty; restore the callback and rerun just lint-workflows`,
-    );
-  for (const line of lines.slice(start + 1)) {
-    if (line.trim() === "") {
-      body.push("");
-      continue;
-    }
-    if (!line.startsWith(indent)) break;
-    body.push(line.slice(indent.length));
-  }
-  return `${body.join("\n")}\n`;
-}
-const callbackDirectory = mkdtempSync(join(tmpdir(), "visual-callback-"));
-try {
-  for (const key of injectedShellCallbacks) {
-    const callbackPath = join(callbackDirectory, `${key}.sh`);
-    writeFileSync(
-      callbackPath,
-      extractBlockScalar(sources[0][1], key).replace(
-        /\$\{\{[^}]*\}\}/g,
-        "expression",
-      ),
-    );
-    const shellcheck = spawnSync(
-      ".tools/bin/shellcheck",
-      ["--shell=sh", callbackPath],
-      { encoding: "utf8" },
-    );
-    if (shellcheck.error)
-      throw new Error(
-        `could not run .tools/bin/shellcheck for ${key}: ${shellcheck.error.message}; run just bootstrap and rerun just lint-workflows`,
-      );
-    if (shellcheck.status !== 0)
-      throw new Error(
-        `${key} is not valid POSIX sh:\n${shellcheck.stdout}${shellcheck.stderr}screencomp runs this callback with the container's /bin/sh, so rewrite it without bash-only constructs and rerun just lint-workflows`,
-      );
-  }
-} finally {
-  rmSync(callbackDirectory, { force: true, recursive: true });
-}
 const nxConfig = JSON.parse(readFileSync("nx.json", "utf8"));
 const homeRspackSource = readFileSync("apps/home/rspack.config.ts", "utf8");
 const remoteMapMatch = homeRspackSource.match(/remoteMap\(\[([\s\S]*?)\]\)/);

--- a/scripts/verify-visual-contract.mjs
+++ b/scripts/verify-visual-contract.mjs
@@ -1,4 +1,7 @@
-import { readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 // llmlint: ignore-file[changed_behavior_has_e2e] This CLI/filesystem quality-gate validator has no browser interface; lint-workflows executes its real boundary against committed workflow, configuration, baselines, and documentation.
 
@@ -46,6 +49,67 @@ const sources = [
   ],
 ];
 const captureSource = readFileSync("scripts/capture-visual.mjs", "utf8");
+
+// screencomp's reusable workflow injects these callbacks into a `run:` step with
+// no `shell:` key, so the container's /bin/sh (dash) runs them — a bash-only
+// construct there does not fail loudly, it takes the `||` branch and reports a
+// bogus domain error, which reads as visual drift in classify-gate. actionlint
+// only shellchecks literal `run:` blocks, so these strings reach CI unlinted
+// unless this gate checks them as POSIX sh.
+const injectedShellCallbacks = ["capture-command"];
+function extractBlockScalar(source, key) {
+  const lines = source.split("\n");
+  const start = lines.findIndex((line) =>
+    new RegExp(`^\\s*${key}:\\s*\\|\\s*$`).test(line),
+  );
+  if (start === -1)
+    throw new Error(
+      `.github/workflows/visual-docs.yml must pass ${key} to the screencomp reusable workflow as a literal block scalar`,
+    );
+  const body = [];
+  const indent = /^\s*/.exec(lines[start + 1] ?? "")[0];
+  if (indent.length <= /^\s*/.exec(lines[start])[0].length)
+    throw new Error(
+      `.github/workflows/visual-docs.yml ${key} block is empty; restore the callback and rerun just lint-workflows`,
+    );
+  for (const line of lines.slice(start + 1)) {
+    if (line.trim() === "") {
+      body.push("");
+      continue;
+    }
+    if (!line.startsWith(indent)) break;
+    body.push(line.slice(indent.length));
+  }
+  return `${body.join("\n")}\n`;
+}
+const callbackDirectory = mkdtempSync(join(tmpdir(), "visual-callback-"));
+try {
+  for (const key of injectedShellCallbacks) {
+    const callbackPath = join(callbackDirectory, `${key}.sh`);
+    writeFileSync(
+      callbackPath,
+      extractBlockScalar(sources[0][1], key).replace(
+        /\$\{\{[^}]*\}\}/g,
+        "expression",
+      ),
+    );
+    const shellcheck = spawnSync(
+      ".tools/bin/shellcheck",
+      ["--shell=sh", callbackPath],
+      { encoding: "utf8" },
+    );
+    if (shellcheck.error)
+      throw new Error(
+        `could not run .tools/bin/shellcheck for ${key}: ${shellcheck.error.message}; run just bootstrap and rerun just lint-workflows`,
+      );
+    if (shellcheck.status !== 0)
+      throw new Error(
+        `${key} is not valid POSIX sh:\n${shellcheck.stdout}${shellcheck.stderr}screencomp runs this callback with the container's /bin/sh, so rewrite it without bash-only constructs and rerun just lint-workflows`,
+      );
+  }
+} finally {
+  rmSync(callbackDirectory, { force: true, recursive: true });
+}
 const nxConfig = JSON.parse(readFileSync("nx.json", "utf8"));
 const homeRspackSource = readFileSync("apps/home/rspack.config.ts", "utf8");
 const remoteMapMatch = homeRspackSource.match(/remoteMap\(\[([\s\S]*?)\]\)/);


### PR DESCRIPTION
## What
Make hover intent actually preload everything a page needs, and make a preloaded page mount instantly:

1. Home panes: export a `preload()` from `apps/home/src/page.tsx` that resolves the seven pane `Page` modules (their `import()` promises already start at module scope, lines ~27-33) and caches the resolved components. Render cached components directly — not through `lazy()`/`Suspense` — once resolved, generalizing the existing entry-at-`/` `hydratedPanes` mechanism (lines 49-69) to client-side navigation. Add a home-route `loader` in `apps/shell/src/router.tsx` that invokes it; the shell already holds the `home/Page` module namespace in `apps/shell/src/main.tsx`, so the export needs no new federation expose — extend the `RoutePages` wiring to carry it. The SSR/prerender path (`scripts/render-entry.tsx` passes plain components) must be unaffected: the loader must no-op or resolve instantly server-side.
2. Software images: extend the software route loader so that after the domain JSON resolves it warms the unique external `logo_url` images (`new Image()`, browser only) so a hover-then-click shows every initially visible card logo with no post-click network fetch.
3. Fast-click path preserved: a click before preload completes still shows the pane/page skeletons and settles correctly.

## Why
The intended UX is: hover a link for a moment, then click, and the switch is instant. Today hovering Home issues no requests at all (the route has no loader) and clicking always flashes skeletons — partly because React `lazy()` suspends on first mount even when its promise already resolved — and hovering Software preloads only the JSON while the logos always load after the click. The owner explicitly wants the full page — code, data, and images — behind a hovered link.
