### PR TITLE
chore(perf): refresh live deployment performance findings

### DIFF
--- a/docs/perf-findings.json
+++ b/docs/perf-findings.json
@@ -2,23 +2,23 @@
   "schemaVersion": 1,
   "runsPerRoute": 5,
   "environment": {
-    "capturedAt": "2026-07-22T04:25:17.303Z",
-    "host": "Linux 6.17.0-1019-aws x64",
-    "cpu": "Intel(R) Xeon(R) Platinum 8488C",
-    "logicalCpus": 4,
-    "memoryGiB": 15.3,
+    "capturedAt": "2026-07-28T05:00:24.859Z",
+    "host": "Linux 6.8.0-136-generic arm64",
+    "cpu": "unknown",
+    "logicalCpus": 14,
+    "memoryGiB": 29.3,
     "node": "v26.5.0",
     "lighthouse": "12.8.2",
     "userAgent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/149.0.0.0 Safari/537.36",
     "formFactor": "desktop",
     "throttlingMethod": "simulate",
     "throttling": {
+      "cpuSlowdownMultiplier": 1,
       "rttMs": 40,
       "throughputKbps": 10240,
       "requestLatencyMs": 0,
       "downloadThroughputKbps": 0,
-      "uploadThroughputKbps": 0,
-      "cpuSlowdownMultiplier": 1
+      "uploadThroughputKbps": 0
     }
   },
   "sites": {
@@ -26,49 +26,49 @@
       "url": "https://nickderobertis.github.io/nick-derobertis-site/",
       "routes": {
         "/": {
-          "performance": 41,
-          "fcp": 230.0287,
-          "lcp": 3927.9916000000003,
-          "tbt": 1894.5000000000002,
-          "cls": 0.1418479560124313,
-          "transferBytes": 3638364,
-          "jsBytes": 3630161
+          "performance": 97,
+          "fcp": 303.7451,
+          "lcp": 426.6023576538086,
+          "tbt": 148,
+          "cls": 0,
+          "transferBytes": 3503541,
+          "jsBytes": 3472535
         },
         "/bio": {
-          "performance": 80,
-          "fcp": 217.68236404418946,
-          "lcp": 792.6689,
-          "tbt": 1,
-          "cls": 0.4417406726540958,
-          "transferBytes": 459644,
-          "jsBytes": 454334
+          "performance": 100,
+          "fcp": 257.4456061401367,
+          "lcp": 382.0046576538086,
+          "tbt": 38,
+          "cls": 0,
+          "transferBytes": 63242,
+          "jsBytes": 57074
         },
         "/research": {
-          "performance": 35,
-          "fcp": 258.807,
-          "lcp": 3068.177,
-          "tbt": 587,
-          "cls": 0.9852292742180383,
-          "transferBytes": 3212971,
-          "jsBytes": 904567
+          "performance": 90,
+          "fcp": 257.7177061401367,
+          "lcp": 2126.6886,
+          "tbt": 57,
+          "cls": 0,
+          "transferBytes": 2799503,
+          "jsBytes": 489563
         },
         "/software": {
-          "performance": 30,
-          "fcp": 266.6948,
-          "lcp": 2216.9798,
-          "tbt": 1163.5,
-          "cls": 0.8825354792995243,
-          "transferBytes": 942288,
-          "jsBytes": 903080
+          "performance": 100,
+          "fcp": 540.9307061401367,
+          "lcp": 659.7611576538086,
+          "tbt": 52,
+          "cls": 0,
+          "transferBytes": 844479,
+          "jsBytes": 489038
         },
         "/courses": {
-          "performance": 43,
-          "fcp": 236.3329,
-          "lcp": 1857.229,
-          "tbt": 648,
-          "cls": 0.9852292742180383,
-          "transferBytes": 908703,
-          "jsBytes": 903785
+          "performance": 100,
+          "fcp": 257.9333061401367,
+          "lcp": 382.1404576538086,
+          "tbt": 65,
+          "cls": 0,
+          "transferBytes": 500907,
+          "jsBytes": 489815
         }
       }
     },
@@ -76,98 +76,98 @@
       "url": "https://nickderobertis.com/",
       "routes": {
         "/": {
-          "performance": 41,
-          "fcp": 1914.0342000000003,
-          "lcp": 2527.75785,
-          "tbt": 4588.000000000002,
-          "cls": 0.000786985662271312,
-          "transferBytes": 4056429,
-          "jsBytes": 1734627
+          "performance": 73,
+          "fcp": 1880.6446,
+          "lcp": 2964.5816999999997,
+          "tbt": 25,
+          "cls": 0.0007843019688663137,
+          "transferBytes": 4206981,
+          "jsBytes": 1734124
         },
         "/bio": {
-          "performance": 80,
-          "fcp": 1722.9636,
-          "lcp": 2067.9293,
-          "tbt": 120.5,
-          "cls": 0,
-          "transferBytes": 2162395,
-          "jsBytes": 1396917
+          "performance": 82,
+          "fcp": 1420.0658999999998,
+          "lcp": 2420.2257,
+          "tbt": 19,
+          "cls": 0.00029770429131288493,
+          "transferBytes": 2326918,
+          "jsBytes": 1396388
         },
         "/research": {
-          "performance": 66,
-          "fcp": 1779.6410999999998,
-          "lcp": 2100.0403,
-          "tbt": 142,
-          "cls": 0.23974911741479019,
-          "transferBytes": 2081690,
-          "jsBytes": 1397127
+          "performance": 70,
+          "fcp": 1420.8114000000003,
+          "lcp": 2337.6124,
+          "tbt": 19.5,
+          "cls": 0.23979951782850178,
+          "transferBytes": 2231941,
+          "jsBytes": 1396381
         },
         "/software": {
-          "performance": 40,
-          "fcp": 1815.3024000000005,
-          "lcp": 2466.1112999999996,
-          "tbt": 339.00000000000045,
-          "cls": 0.5283112569514021,
-          "transferBytes": 2480854,
-          "jsBytes": 1397116
+          "performance": 63,
+          "fcp": 1507.9506,
+          "lcp": 1979.7365999999997,
+          "tbt": 19,
+          "cls": 0.5286710978694479,
+          "transferBytes": 2631141,
+          "jsBytes": 1396739
         },
         "/courses": {
           "performance": 72,
-          "fcp": 1737.3136,
-          "lcp": 2309.7933999999996,
-          "tbt": 108.5,
-          "cls": 0.1581233564427444,
-          "transferBytes": 2736964,
-          "jsBytes": 1397143
+          "fcp": 1423.5698,
+          "lcp": 2945.5025999999993,
+          "tbt": 20,
+          "cls": 0.1583927368603961,
+          "transferBytes": 2887289,
+          "jsBytes": 1396693
         }
       }
     }
   },
   "deltas": {
     "/": {
-      "performance": 0,
-      "fcp": -1684.0055000000002,
-      "lcp": 1400.2337500000003,
-      "tbt": -2693.500000000002,
-      "cls": 0.14106097035016,
-      "transferBytes": -418065,
-      "jsBytes": 1895534
+      "performance": 24,
+      "fcp": -1576.8995,
+      "lcp": -2537.979342346191,
+      "tbt": 123,
+      "cls": -0.0007843019688663137,
+      "transferBytes": -703440,
+      "jsBytes": 1738411
     },
     "/bio": {
-      "performance": 0,
-      "fcp": -1505.2812359558106,
-      "lcp": -1275.2603999999997,
-      "tbt": -119.5,
-      "cls": 0.4417406726540958,
-      "transferBytes": -1702751,
-      "jsBytes": -942583
+      "performance": 18,
+      "fcp": -1162.620293859863,
+      "lcp": -2038.2210423461913,
+      "tbt": 19,
+      "cls": -0.00029770429131288493,
+      "transferBytes": -2263676,
+      "jsBytes": -1339314
     },
     "/research": {
-      "performance": -31,
-      "fcp": -1520.8340999999998,
-      "lcp": 968.1367,
-      "tbt": 445,
-      "cls": 0.7454801568032481,
-      "transferBytes": 1131281,
-      "jsBytes": -492560
+      "performance": 20,
+      "fcp": -1163.0936938598636,
+      "lcp": -210.92380000000003,
+      "tbt": 37.5,
+      "cls": -0.23979951782850178,
+      "transferBytes": 567562,
+      "jsBytes": -906818
     },
     "/software": {
-      "performance": -10,
-      "fcp": -1548.6076000000005,
-      "lcp": -249.1314999999995,
-      "tbt": 824.4999999999995,
-      "cls": 0.3542242223481221,
-      "transferBytes": -1538566,
-      "jsBytes": -494036
+      "performance": 37,
+      "fcp": -967.0198938598631,
+      "lcp": -1319.9754423461911,
+      "tbt": 33,
+      "cls": -0.5286710978694479,
+      "transferBytes": -1786662,
+      "jsBytes": -907701
     },
     "/courses": {
-      "performance": -29,
-      "fcp": -1500.9807,
-      "lcp": -452.5643999999995,
-      "tbt": 539.5,
-      "cls": 0.827105917775294,
-      "transferBytes": -1828261,
-      "jsBytes": -493358
+      "performance": 28,
+      "fcp": -1165.6364938598633,
+      "lcp": -2563.362142346191,
+      "tbt": 45,
+      "cls": -0.1583927368603961,
+      "transferBytes": -2386382,
+      "jsBytes": -906878
     }
   }
 }

--- a/docs/perf-report.md
+++ b/docs/perf-report.md
@@ -1,6 +1,6 @@
 # Deployment performance comparison
 
-Generated 2026-07-22T04:25:17.303Z with Lighthouse 12.8.2 using 5 runs per route. Timing values are the median of all runs; byte and score values are also medians for consistency.
+Generated 2026-07-28T05:00:24.859Z with Lighthouse 12.8.2 using 5 runs per route. Timing values are the median of all runs; byte and score values are also medians for consistency.
 
 > Absolute CPU- and network-bound timings are host-dependent because these audits run from a shared host against live deployments. Compare runs made on the same representative host. Transfer bytes and CLS deltas are substantially more stable.
 
@@ -8,7 +8,7 @@ Generated 2026-07-22T04:25:17.303Z with Lighthouse 12.8.2 using 5 runs per route
 
 - Explicit Lighthouse preset: `desktop` (desktop form factor, `simulate` throttling)
 - Applied throttling: `{"cpuSlowdownMultiplier":1,"rttMs":40,"throughputKbps":10240,"requestLatencyMs":0,"downloadThroughputKbps":0,"uploadThroughputKbps":0}`
-- Host: Linux 6.17.0-1019-aws x64; Intel(R) Xeon(R) Platinum 8488C; 4 logical CPUs; 15.3 GiB RAM
+- Host: Linux 6.8.0-136-generic arm64; unknown; 14 logical CPUs; 29.3 GiB RAM
 - Runtime: v26.5.0; user agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/149.0.0.0 Safari/537.36
 - New deployment: https://nickderobertis.github.io/nick-derobertis-site/
 - Original deployment: https://nickderobertis.com/
@@ -19,59 +19,59 @@ Lower is better for every metric except Performance score, where higher is bette
 
 | Metric | New | Original | Delta |
 | --- | ---: | ---: | ---: |
-| Performance | 41 | 41 | 0 |
-| FCP | 230 ms | 1914 ms | -1684 ms |
-| LCP | 3928 ms | 2528 ms | +1400 ms |
-| TBT | 1895 ms | 4588 ms | -2694 ms |
-| CLS | 0.142 | 0.001 | +0.141 |
-| Transfer | 3553.1 KiB | 3961.4 KiB | -408.3 KiB |
-| JavaScript | 3545.1 KiB | 1694.0 KiB | +1851.1 KiB |
+| Performance | 97 | 73 | +24 |
+| FCP | 304 ms | 1881 ms | -1577 ms |
+| LCP | 427 ms | 2965 ms | -2538 ms |
+| TBT | 148 ms | 25 ms | +123 ms |
+| CLS | 0.000 | 0.001 | -0.001 |
+| Transfer | 3421.4 KiB | 4108.4 KiB | -687.0 KiB |
+| JavaScript | 3391.1 KiB | 1693.5 KiB | +1697.7 KiB |
 
 ## `/bio`
 
 | Metric | New | Original | Delta |
 | --- | ---: | ---: | ---: |
-| Performance | 80 | 80 | 0 |
-| FCP | 218 ms | 1723 ms | -1505 ms |
-| LCP | 793 ms | 2068 ms | -1275 ms |
-| TBT | 1 ms | 121 ms | -119 ms |
-| CLS | 0.442 | 0.000 | +0.442 |
-| Transfer | 448.9 KiB | 2111.7 KiB | -1662.8 KiB |
-| JavaScript | 443.7 KiB | 1364.2 KiB | -920.5 KiB |
+| Performance | 100 | 82 | +18 |
+| FCP | 257 ms | 1420 ms | -1163 ms |
+| LCP | 382 ms | 2420 ms | -2038 ms |
+| TBT | 38 ms | 19 ms | +19 ms |
+| CLS | 0.000 | 0.000 | -0.000 |
+| Transfer | 61.8 KiB | 2272.4 KiB | -2210.6 KiB |
+| JavaScript | 55.7 KiB | 1363.7 KiB | -1307.9 KiB |
 
 ## `/research`
 
 | Metric | New | Original | Delta |
 | --- | ---: | ---: | ---: |
-| Performance | 35 | 66 | -31 |
-| FCP | 259 ms | 1780 ms | -1521 ms |
-| LCP | 3068 ms | 2100 ms | +968 ms |
-| TBT | 587 ms | 142 ms | +445 ms |
-| CLS | 0.985 | 0.240 | +0.745 |
-| Transfer | 3137.7 KiB | 2032.9 KiB | +1104.8 KiB |
-| JavaScript | 883.4 KiB | 1364.4 KiB | -481.0 KiB |
+| Performance | 90 | 70 | +20 |
+| FCP | 258 ms | 1421 ms | -1163 ms |
+| LCP | 2127 ms | 2338 ms | -211 ms |
+| TBT | 57 ms | 20 ms | +38 ms |
+| CLS | 0.000 | 0.240 | -0.240 |
+| Transfer | 2733.9 KiB | 2179.6 KiB | +554.3 KiB |
+| JavaScript | 478.1 KiB | 1363.7 KiB | -885.6 KiB |
 
 ## `/software`
 
 | Metric | New | Original | Delta |
 | --- | ---: | ---: | ---: |
-| Performance | 30 | 40 | -10 |
-| FCP | 267 ms | 1815 ms | -1549 ms |
-| LCP | 2217 ms | 2466 ms | -249 ms |
-| TBT | 1164 ms | 339 ms | +824 ms |
-| CLS | 0.883 | 0.528 | +0.354 |
-| Transfer | 920.2 KiB | 2422.7 KiB | -1502.5 KiB |
-| JavaScript | 881.9 KiB | 1364.4 KiB | -482.5 KiB |
+| Performance | 100 | 63 | +37 |
+| FCP | 541 ms | 1508 ms | -967 ms |
+| LCP | 660 ms | 1980 ms | -1320 ms |
+| TBT | 52 ms | 19 ms | +33 ms |
+| CLS | 0.000 | 0.529 | -0.529 |
+| Transfer | 824.7 KiB | 2569.5 KiB | -1744.8 KiB |
+| JavaScript | 477.6 KiB | 1364.0 KiB | -886.4 KiB |
 
 ## `/courses`
 
 | Metric | New | Original | Delta |
 | --- | ---: | ---: | ---: |
-| Performance | 43 | 72 | -29 |
-| FCP | 236 ms | 1737 ms | -1501 ms |
-| LCP | 1857 ms | 2310 ms | -453 ms |
-| TBT | 648 ms | 109 ms | +540 ms |
-| CLS | 0.985 | 0.158 | +0.827 |
-| Transfer | 887.4 KiB | 2672.8 KiB | -1785.4 KiB |
-| JavaScript | 882.6 KiB | 1364.4 KiB | -481.8 KiB |
+| Performance | 100 | 72 | +28 |
+| FCP | 258 ms | 1424 ms | -1166 ms |
+| LCP | 382 ms | 2946 ms | -2563 ms |
+| TBT | 65 ms | 20 ms | +45 ms |
+| CLS | 0.000 | 0.158 | -0.158 |
+| Transfer | 489.2 KiB | 2819.6 KiB | -2330.5 KiB |
+| JavaScript | 478.3 KiB | 1364.0 KiB | -885.6 KiB |
 


### PR DESCRIPTION
## What

Re-audit the live GitHub Pages deployment and refresh the committed
performance baseline (`docs/perf-findings.json`, `docs/perf-report.md`)
via `just perf` (5 runs per route, Lighthouse `desktop` preset, routes
`/`, `/bio`, `/research`, `/software`, `/courses`).

## Deployment verified before measuring

Audited the Pages deployment of master `6e30f8b` (deploy run
`30329710900`, success) — the first deployment carrying all three
loading changes. Verified from the fetched deployed HTML and live
browser instrumentation, not from the source tree:

- **Inlined per-route CSS (#52)** — `/` ships 8 inline `<style>` blocks
  totalling 29,811 chars in `<head>`; `/software` ships 5,549 chars.
  Previously only the 767-byte shell stylesheet was linked.
- **Active-route-only hydration (#55)** — loading `/` fetched
  `remotes/home/remoteEntry.js` plus its 7 pane remotes and made zero
  requests for the `bio`, `research`, `software`, and `courses`
  remoteEntries.
- **Hover-intent preload (#53)** — hovering the Software nav link
  fetched its `remoteEntry.js`, `software_projects.json`, and 14
  external logo images; the following click issued only 2 further
  requests and rendered "Open-Source Software".

## Results

Layout shift is eliminated on every audited route and LCP drops sharply:

| Route | CLS before | CLS after | LCP before | LCP after |
| --- | ---: | ---: | ---: | ---: |
| `/` | 0.142 | 0.000 | 3928 ms | 427 ms |
| `/software` | 0.883 | 0.000 | 2217 ms | 660 ms |

The unchanged original deployment (`nickderobertis.com`) is audited in
the same run as a control; its CLS held steady across both captures
(e.g. `/software` 0.5283 -> 0.5287), so the CLS collapse is attributable
to the rework rather than to the capture host.

## Regressions

- FCP regressed on four routes: `/software` +274 ms (267 -> 541),
  `/` +74 ms (230 -> 304), `/bio` +40 ms (218 -> 257), `/courses`
  +22 ms (236 -> 258). This is the expected cost of inlining
  render-blocking route CSS into a larger HTML document; the document
  now paints fully styled, which is what removes the shift and lowers
  LCP. The control site's FCP *improved* over the same interval, so
  this is a real regression rather than host noise.
- `/bio` TBT rose from 1 ms to 38 ms.

## Caveat

This capture ran on a Linux aarch64 host with 14 logical CPUs; the prior
findings came from a 4-CPU x64 host. The control site's TBT moved
4588 ms -> 25 ms on `/` on its own, so CPU-bound TBT deltas are not
comparable across the two captures. CLS and byte counts are host-stable
and are the trustworthy comparisons here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)