### PR TITLE
fix: gate documented gallery URLs against the deployed layout; document…

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,11 +27,16 @@ to `screencomp classify --include project=<app>` scoping against a shared
 baseline. The single drift gate is the reusable workflow's classify job (surfaced
 as the `Visual docs` workflow's stable `classify-gate` status check); its local
 half is `.githooks/pre-push` (enable once per clone with `git config
-core.hooksPath .githooks`). Galleries are published at
-`https://nickderobertis.github.io/nick-derobertis-site-visual-docs/` from the
-dedicated visual-docs repository. They cannot be hosted on this repository's
-`gh-pages` branch because its production Pages site is served from an Actions
-artifact, so GitHub does not serve that branch. Pin screencomp `v0.4.5`
+core.hooksPath .githooks`). Galleries are published per project from the
+dedicated visual-docs repository — canonical ones at
+`https://nickderobertis.github.io/nick-derobertis-site-visual-docs/<project>/x86_64/`
+and pull-request previews at
+`https://nickderobertis.github.io/nick-derobertis-site-visual-docs/pr-<number>/<project>/x86_64/`.
+There is no root index; the aggregated pull-request comment carries the direct
+links and is the intended entry point. Only affected projects are deployed, so
+most projects have no gallery at any given moment. Galleries cannot be hosted
+on this repository's `gh-pages` branch because its production Pages site is
+served from an Actions artifact, so GitHub does not serve that branch. Pin screencomp `v0.4.5`
 consistently across the
 reusable-workflow ref, the `screencomp-version` input, and the bootstrap CLI
 install; `scripts/verify-visual-contract.mjs` guards that and the toggle/baseline

--- a/README.md
+++ b/README.md
@@ -55,11 +55,21 @@ sweep. See [the architecture](docs/architecture.md) for project boundaries,
 hosting, and affected-test behavior.
 
 Pull requests with affected visual projects get one aggregated screencomp
-comment with real before/after diffs and links to the galleries at
-<https://nickderobertis.github.io/nick-derobertis-site-visual-docs/>. The
-galleries use a dedicated Pages repository because this repository's production
-Pages site is deployed from an Actions artifact; GitHub therefore does not serve
-its `gh-pages` branch, even when screencomp writes galleries there.
+comment with real before/after diffs and direct gallery links; that comment is
+the intended entry point. Galleries are published per project, not at a site
+root — there is no index page:
+
+- canonical (`master`):
+  `https://nickderobertis.github.io/nick-derobertis-site-visual-docs/<project>/x86_64/`
+- pull-request preview:
+  `https://nickderobertis.github.io/nick-derobertis-site-visual-docs/pr-<number>/<project>/x86_64/`
+
+Only affected projects are captured and deployed, so a project has a gallery
+only once it has been affected; previews are pruned when the pull request
+closes. The galleries use a dedicated Pages repository because this
+repository's production Pages site is deployed from an Actions artifact; GitHub
+therefore does not serve its `gh-pages` branch, even when screencomp writes
+galleries there.
 
 ## Deployment performance
 

--- a/apps/shell-e2e/src/unit/visual-affected.spec.ts
+++ b/apps/shell-e2e/src/unit/visual-affected.spec.ts
@@ -68,6 +68,66 @@ function affectedProjectsMatrix(file: string): VisualProject[] {
   return projectsMatrix(affectedScreenshotProjects(file));
 }
 
+// screencomp only ever deploys <project>/<arch> and pr-<number>/<project>/<arch>,
+// so a doc that advertises the bare Pages root — or drops one of the deployed
+// forms — sends readers to a permanent 404. Every URL the gallery-documentation
+// tests use is assembled from visual-tools.json rather than written out, so this
+// file never carries a copyable dead link of its own.
+function galleryContract(): {
+  pagesRoot: string;
+  canonical: string;
+  preview: string;
+} {
+  const contract: unknown = JSON.parse(
+    readFileSync("visual-tools.json", "utf8"),
+  );
+  const { architecture, pagesRepository } =
+    typeof contract === "object" && contract !== null
+      ? (contract as { architecture?: unknown; pagesRepository?: unknown })
+      : {};
+  if (
+    typeof pagesRepository !== "string" ||
+    !/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(pagesRepository) ||
+    typeof architecture !== "string" ||
+    !/^[A-Za-z0-9_-]+$/.test(architecture)
+  )
+    throw new Error(
+      "visual-tools.json must declare an owner/name pagesRepository and an architecture",
+    );
+  const [owner, name] = pagesRepository.split("/");
+  const pagesRoot = `https://${owner}.github.io/${name}`;
+  return {
+    pagesRoot,
+    canonical: `${pagesRoot}/<project>/${architecture}/`,
+    preview: `${pagesRoot}/pr-<number>/<project>/${architecture}/`,
+  };
+}
+
+// Run the real contract gate over the committed tree with one root-level
+// document swapped out. Every entry is symlinked, so only the replaced symlink is
+// removed — a nested path would delete the real file through its linked
+// directory, which is why this is restricted to root-level documents.
+function verifyContractWithRootDocument(
+  document: string,
+  contents: string,
+): { status: number | null; stderr: string } {
+  if (document.includes("/"))
+    throw new Error(`${document} must be a root-level document`);
+  const root = mkdtempSync(path.join(tmpdir(), "visual-contract-"));
+  try {
+    for (const entry of readdirSync("."))
+      symlinkSync(path.resolve(entry), path.join(root, entry));
+    rmSync(path.join(root, document));
+    writeFileSync(path.join(root, document), contents);
+    return spawnSync("node", ["scripts/verify-visual-contract.mjs"], {
+      cwd: root,
+      encoding: "utf8",
+    });
+  } finally {
+    rmSync(root, { force: true, recursive: true });
+  }
+}
+
 describe("visual affected selection", () => {
   test("a remote change recaptures only that remote", () => {
     expect(affectedScreenshotProjects("apps/skills/src/page.tsx")).toEqual([
@@ -181,41 +241,26 @@ describe("visual affected selection", () => {
     ).not.toThrow();
   });
 
-  // screencomp only ever deploys <project>/<arch> and pr-<number>/<project>/<arch>,
-  // so a doc that advertises the bare Pages root sends readers to a permanent 404.
-  // The invalid root is assembled from visual-tools.json rather than written out,
-  // so this file never carries a copyable dead link of its own.
   test("gallery documentation cannot advertise the undeployed Pages root", () => {
-    const contract: unknown = JSON.parse(
-      readFileSync("visual-tools.json", "utf8"),
-    );
-    const pagesRepository =
-      typeof contract === "object" && contract !== null
-        ? (contract as { pagesRepository?: unknown }).pagesRepository
-        : undefined;
-    if (
-      typeof pagesRepository !== "string" ||
-      !/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(pagesRepository)
-    )
-      throw new Error(
-        "visual-tools.json must declare pagesRepository owner/name",
+    const { pagesRoot } = galleryContract();
+    for (const deadLink of [`${pagesRoot}/`, pagesRoot]) {
+      const result = verifyContractWithRootDocument(
+        "README.md",
+        `${readFileSync("README.md", "utf8")}\nSee the galleries at\n<${deadLink}>.\n`,
       );
-    const [owner, name] = pagesRepository.split("/");
-    const root = mkdtempSync(path.join(tmpdir(), "visual-contract-"));
-    for (const entry of readdirSync("."))
-      symlinkSync(path.resolve(entry), path.join(root, entry));
-    rmSync(path.join(root, "README.md"));
-    writeFileSync(
-      path.join(root, "README.md"),
-      `${readFileSync("README.md", "utf8")}\nSee the galleries at\n<https://${owner}.github.io/${name}/>.\n`,
+      expect(result.status, deadLink).not.toBe(0);
+      expect(result.stderr, deadLink).toContain("advertises the bare");
+    }
+  });
+
+  test("gallery documentation must carry both deployed URL forms", () => {
+    const { canonical, preview } = galleryContract();
+    const result = verifyContractWithRootDocument(
+      "README.md",
+      readFileSync("README.md", "utf8").replaceAll(canonical, preview),
     );
-    const result = spawnSync("node", ["scripts/verify-visual-contract.mjs"], {
-      cwd: root,
-      encoding: "utf8",
-    });
-    rmSync(root, { force: true, recursive: true });
     expect(result.status).not.toBe(0);
-    expect(result.stderr).toContain("advertises the bare");
+    expect(result.stderr).toContain(`must document ${canonical}`);
   });
 
   test("bootstrap provisions pinned workflow and shell linters without ambient tools", () => {

--- a/apps/shell-e2e/src/unit/visual-affected.spec.ts
+++ b/apps/shell-e2e/src/unit/visual-affected.spec.ts
@@ -1,4 +1,13 @@
 import { execFileSync, spawnSync } from "node:child_process";
+import {
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import { describe, expect, test } from "vitest";
 
@@ -170,6 +179,26 @@ describe("visual affected selection", () => {
         encoding: "utf8",
       }),
     ).not.toThrow();
+  });
+
+  // screencomp only ever deploys <project>/<arch> and pr-<number>/<project>/<arch>,
+  // so a doc that advertises the bare Pages root sends readers to a permanent 404.
+  test("gallery documentation cannot advertise the undeployed Pages root", () => {
+    const root = mkdtempSync(path.join(tmpdir(), "visual-contract-"));
+    for (const entry of readdirSync("."))
+      symlinkSync(path.resolve(entry), path.join(root, entry));
+    rmSync(path.join(root, "README.md"));
+    writeFileSync(
+      path.join(root, "README.md"),
+      `${readFileSync("README.md", "utf8")}\nSee the galleries at\n<https://nickderobertis.github.io/nick-derobertis-site-visual-docs/>.\n`,
+    );
+    const result = spawnSync("node", ["scripts/verify-visual-contract.mjs"], {
+      cwd: root,
+      encoding: "utf8",
+    });
+    rmSync(root, { force: true, recursive: true });
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("advertises the bare");
   });
 
   test("bootstrap provisions pinned workflow and shell linters without ambient tools", () => {

--- a/apps/shell-e2e/src/unit/visual-affected.spec.ts
+++ b/apps/shell-e2e/src/unit/visual-affected.spec.ts
@@ -183,14 +183,31 @@ describe("visual affected selection", () => {
 
   // screencomp only ever deploys <project>/<arch> and pr-<number>/<project>/<arch>,
   // so a doc that advertises the bare Pages root sends readers to a permanent 404.
+  // The invalid root is assembled from visual-tools.json rather than written out,
+  // so this file never carries a copyable dead link of its own.
   test("gallery documentation cannot advertise the undeployed Pages root", () => {
+    const contract: unknown = JSON.parse(
+      readFileSync("visual-tools.json", "utf8"),
+    );
+    const pagesRepository =
+      typeof contract === "object" && contract !== null
+        ? (contract as { pagesRepository?: unknown }).pagesRepository
+        : undefined;
+    if (
+      typeof pagesRepository !== "string" ||
+      !/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(pagesRepository)
+    )
+      throw new Error(
+        "visual-tools.json must declare pagesRepository owner/name",
+      );
+    const [owner, name] = pagesRepository.split("/");
     const root = mkdtempSync(path.join(tmpdir(), "visual-contract-"));
     for (const entry of readdirSync("."))
       symlinkSync(path.resolve(entry), path.join(root, entry));
     rmSync(path.join(root, "README.md"));
     writeFileSync(
       path.join(root, "README.md"),
-      `${readFileSync("README.md", "utf8")}\nSee the galleries at\n<https://nickderobertis.github.io/nick-derobertis-site-visual-docs/>.\n`,
+      `${readFileSync("README.md", "utf8")}\nSee the galleries at\n<https://${owner}.github.io/${name}/>.\n`,
     );
     const result = spawnSync("node", ["scripts/verify-visual-contract.mjs"], {
       cwd: root,

--- a/docs/integration-proof.md
+++ b/docs/integration-proof.md
@@ -93,11 +93,15 @@ affected app fresh in that container and classifying it against the committed,
 image-free baseline manifest — a byte-digest comparison, so a one-pixel layout,
 content, or color change fails:
 
-The reusable workflow publishes canonical and pull-request galleries to the
-dedicated visual-docs Pages site at
-<https://nickderobertis.github.io/nick-derobertis-site-visual-docs/> and posts
-one aggregated pull-request comment with inline before/after diffs when the
-change set is small. This repository cannot serve galleries from its own
+The reusable workflow publishes galleries to the dedicated visual-docs Pages
+site one directory per project — canonical galleries for the default branch at
+`https://nickderobertis.github.io/nick-derobertis-site-visual-docs/<project>/x86_64/`
+and pull-request previews at
+`https://nickderobertis.github.io/nick-derobertis-site-visual-docs/pr-<number>/<project>/x86_64/`.
+No root index is written, and only affected projects are deployed. The
+aggregated pull-request comment — which also carries inline before/after diffs
+when the change set is small — holds the direct links and is the intended entry
+point. This repository cannot serve galleries from its own
 `gh-pages` branch: its production Pages site uses an Actions artifact
 deployment, so GitHub serves that artifact rather than the branch. Keeping the
 gallery branch in a separate repository preserves the production deployment.

--- a/scripts/verify-visual-contract.mjs
+++ b/scripts/verify-visual-contract.mjs
@@ -159,12 +159,32 @@ if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(contract.pagesRepository))
   throw new Error(
     "Visual pagesRepository must be an owner/name; correct pagesRepository in visual-tools.json and rerun just lint-workflows",
   );
-const pagesUrl = `https://${contract.pagesRepository.split("/")[0]}.github.io/${contract.pagesRepository.split("/")[1]}/`;
-for (const path of ["AGENTS.md", "README.md", "docs/integration-proof.md"])
-  if (!readFileSync(path, "utf8").includes(pagesUrl))
+// screencomp's visual-docs action deploys canonical galleries to
+// <project>/<arch> and pull-request previews to pr-<number>/<project>/<arch>.
+// It never writes a root index, so documenting the bare Pages root advertises a
+// permanent 404. Both URL forms are derived from visual-tools.json here so the
+// docs cannot drift from the deployed layout or from an architecture bump.
+const [pagesOwner, pagesName] = contract.pagesRepository.split("/");
+const pagesRoot = `https://${pagesOwner}.github.io/${pagesName}`;
+const galleryUrls = [
+  `${pagesRoot}/<project>/${contract.architecture}/`,
+  `${pagesRoot}/pr-<number>/<project>/${contract.architecture}/`,
+];
+const bareRoot = new RegExp(
+  `${pagesRoot.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}/(?![a-z<])`,
+);
+for (const path of ["AGENTS.md", "README.md", "docs/integration-proof.md"]) {
+  const documentation = readFileSync(path, "utf8");
+  for (const url of galleryUrls)
+    if (!documentation.includes(url))
+      throw new Error(
+        `Visual gallery documentation in ${path} must document ${url}`,
+      );
+  if (bareRoot.test(documentation))
     throw new Error(
-      `Visual gallery documentation in ${path} must link to ${pagesUrl}`,
+      `Visual gallery documentation in ${path} advertises the bare ${pagesRoot}/ root, which screencomp never deploys; document the per-project gallery URLs instead`,
     );
+}
 const screencompSource = sources.find(
   ([name]) => name === "screencomp config",
 )[1];

--- a/scripts/verify-visual-contract.mjs
+++ b/scripts/verify-visual-contract.mjs
@@ -170,8 +170,10 @@ const galleryUrls = [
   `${pagesRoot}/<project>/${contract.architecture}/`,
   `${pagesRoot}/pr-<number>/<project>/${contract.architecture}/`,
 ];
+// Every mention of the site must therefore continue into a project or pr-<number>
+// segment; anything else — with or without a trailing slash — is the bare root.
 const bareRoot = new RegExp(
-  `${pagesRoot.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}/(?![a-z<])`,
+  `${pagesRoot.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}(?!/[A-Za-z0-9<])`,
 );
 for (const path of ["AGENTS.md", "README.md", "docs/integration-proof.md"]) {
   const documentation = readFileSync(path, "utf8");
@@ -182,7 +184,7 @@ for (const path of ["AGENTS.md", "README.md", "docs/integration-proof.md"]) {
       );
   if (bareRoot.test(documentation))
     throw new Error(
-      `Visual gallery documentation in ${path} advertises the bare ${pagesRoot}/ root, which screencomp never deploys; document the per-project gallery URLs instead`,
+      `Visual gallery documentation in ${path} advertises the bare ${pagesRoot} Pages root, which screencomp never deploys; document the per-project gallery URLs instead`,
     );
 }
 const screencompSource = sources.find(


### PR DESCRIPTION
## What
Recover lifecycle-preserved work after explicit verification.

## Why
The original dispatch did not complete; this branch now carries a verified recovery attestation.
