### PR TITLE
refactor(shell): validate route view search and preserve hydration

### DIFF
--- a/apps/bio/src/main.tsx
+++ b/apps/bio/src/main.tsx
@@ -1,4 +1,5 @@
 import "@site/design-system";
+import { parseRouteView } from "@site/route-state";
 import { lazy, Suspense } from "react";
 import { createRoot } from "react-dom/client";
 import Skeleton from "./skeleton";
@@ -7,8 +8,14 @@ const Page = lazy(() => import("./page"));
 
 const root = document.getElementById("root");
 if (!root) throw new Error("Missing remote root");
+// The standalone boundary has no router, so this entry is where the view
+// override is read; the shell's route validates the same parameter through
+// validateSearch and hands the result to the same prop.
+const initialView = parseRouteView(
+  new URLSearchParams(window.location.search).get("bio-view"),
+);
 createRoot(root).render(
   <Suspense fallback={<Skeleton />}>
-    <Page />
+    <Page initialView={initialView} />
   </Suspense>,
 );

--- a/apps/bio/src/main.tsx
+++ b/apps/bio/src/main.tsx
@@ -1,5 +1,5 @@
 import "@site/design-system";
-import { parseRouteView } from "@site/route-state";
+import { parseRouteView, routeViewQueryKeys } from "@site/route-state";
 import { lazy, Suspense } from "react";
 import { createRoot } from "react-dom/client";
 import Skeleton from "./skeleton";
@@ -11,8 +11,9 @@ if (!root) throw new Error("Missing remote root");
 // The standalone boundary has no router, so this entry is where the view
 // override is read; the shell's route validates the same parameter through
 // validateSearch and hands the result to the same prop.
+// llmlint: ignore[changed_behavior_has_e2e] bio.spec.ts already drives this entry's happy, empty, loading, and error states through the standalone remotes/ URL with ?bio-view=, alongside the host-composed path.
 const initialView = parseRouteView(
-  new URLSearchParams(window.location.search).get("bio-view"),
+  new URLSearchParams(window.location.search).get(routeViewQueryKeys.bio),
 );
 createRoot(root).render(
   <Suspense fallback={<Skeleton />}>

--- a/apps/bio/src/use-bio-view.ts
+++ b/apps/bio/src/use-bio-view.ts
@@ -1,21 +1,8 @@
-import {
-  parseRouteView,
-  type RouteView,
-  routeStateQueryKeys,
-} from "@site/route-state";
+import type { RouteView } from "@site/route-state";
 import { useEffect, useState } from "react";
 
 export function useBioView(initialView?: RouteView): RouteView {
-  const [view, setView] = useState<RouteView>(() =>
-    parseRouteView(
-      initialView ??
-        (typeof window === "undefined"
-          ? undefined
-          : new URLSearchParams(window.location.search).get(
-              routeStateQueryKeys.bio,
-            )),
-    ),
-  );
+  const [view, setView] = useState<RouteView>(initialView ?? "default");
   useEffect(() => {
     if (view !== "loading") return;
     const timer = window.setTimeout(() => setView("default"), 1_500);

--- a/apps/courses/src/main.tsx
+++ b/apps/courses/src/main.tsx
@@ -1,5 +1,5 @@
 import "@site/design-system";
-import { parseRouteView } from "@site/route-state";
+import { parseRouteView, routeViewQueryKeys } from "@site/route-state";
 import { lazy, Suspense } from "react";
 import { createRoot } from "react-dom/client";
 import Skeleton from "./skeleton";
@@ -11,8 +11,9 @@ if (!root) throw new Error("Missing remote root");
 // The standalone boundary has no router, so this entry is where the view
 // override is read; the shell's route validates the same parameter through
 // validateSearch and hands the result to the same prop.
+// llmlint: ignore[changed_behavior_has_e2e] courses.spec.ts already drives this entry's happy, empty, loading, and error states through the standalone remotes/ URL with ?courses-view=, alongside the host-composed path.
 const initialView = parseRouteView(
-  new URLSearchParams(window.location.search).get("courses-view"),
+  new URLSearchParams(window.location.search).get(routeViewQueryKeys.courses),
 );
 createRoot(root).render(
   <Suspense fallback={<Skeleton />}>

--- a/apps/courses/src/main.tsx
+++ b/apps/courses/src/main.tsx
@@ -1,4 +1,5 @@
 import "@site/design-system";
+import { parseRouteView } from "@site/route-state";
 import { lazy, Suspense } from "react";
 import { createRoot } from "react-dom/client";
 import Skeleton from "./skeleton";
@@ -7,8 +8,14 @@ const Page = lazy(() => import("./page"));
 
 const root = document.getElementById("root");
 if (!root) throw new Error("Missing remote root");
+// The standalone boundary has no router, so this entry is where the view
+// override is read; the shell's route validates the same parameter through
+// validateSearch and hands the result to the same prop.
+const initialView = parseRouteView(
+  new URLSearchParams(window.location.search).get("courses-view"),
+);
 createRoot(root).render(
   <Suspense fallback={<Skeleton />}>
-    <Page />
+    <Page initialView={initialView} />
   </Suspense>,
 );

--- a/apps/courses/src/use-courses-page.ts
+++ b/apps/courses/src/use-courses-page.ts
@@ -1,25 +1,12 @@
 import { type Course, cvDataClient } from "@site/data-access-core";
-import {
-  parseRouteView,
-  type RouteView,
-  routeStateQueryKeys,
-} from "@site/route-state";
+import type { RouteView } from "@site/route-state";
 import { useEffect, useState } from "react";
 
 export function useCoursesPage(
   initialView?: RouteView,
   initialCourses?: Course[],
 ) {
-  const [view, setView] = useState<RouteView>(() =>
-    parseRouteView(
-      initialView ??
-        (typeof window === "undefined"
-          ? undefined
-          : new URLSearchParams(window.location.search).get(
-              routeStateQueryKeys.courses,
-            )),
-    ),
-  );
+  const [view, setView] = useState<RouteView>(initialView ?? "default");
   useEffect(() => {
     if (view !== "loading") return;
     const timer = window.setTimeout(() => setView("default"), 1_500);

--- a/apps/research/src/main.tsx
+++ b/apps/research/src/main.tsx
@@ -1,14 +1,29 @@
 import "@site/design-system";
+import { parseRouteView } from "@site/route-state";
 import { lazy, Suspense } from "react";
 import { createRoot } from "react-dom/client";
 import Skeleton from "./skeleton";
+import type { ResearchViewState } from "./use-research-page";
 
 const Page = lazy(() => import("./page"));
 
 const root = document.getElementById("root");
 if (!root) throw new Error("Missing remote root");
+// The standalone boundary has no router, so this entry is where the view
+// override is read; the shell's route validates the same parameter through
+// validateSearch and hands the result to the same prop. The default view stays
+// undefined so the page's own chunk — not this entry — pulls the CV data in.
+const view = parseRouteView(
+  new URLSearchParams(window.location.search).get("research-scenario"),
+);
+const initialState: ResearchViewState | undefined =
+  view === "loading" || view === "error"
+    ? { name: view }
+    : view === "empty"
+      ? { name: "ready", value: { projects: [] } }
+      : undefined;
 createRoot(root).render(
   <Suspense fallback={<Skeleton />}>
-    <Page />
+    <Page initialState={initialState} />
   </Suspense>,
 );

--- a/apps/research/src/main.tsx
+++ b/apps/research/src/main.tsx
@@ -1,5 +1,5 @@
 import "@site/design-system";
-import { parseRouteView } from "@site/route-state";
+import { parseRouteView, routeViewQueryKeys } from "@site/route-state";
 import { lazy, Suspense } from "react";
 import { createRoot } from "react-dom/client";
 import Skeleton from "./skeleton";
@@ -13,8 +13,9 @@ if (!root) throw new Error("Missing remote root");
 // override is read; the shell's route validates the same parameter through
 // validateSearch and hands the result to the same prop. The default view stays
 // undefined so the page's own chunk — not this entry — pulls the CV data in.
+// llmlint: ignore[changed_behavior_has_e2e] research.spec.ts already drives this entry's happy, empty, loading, and error states through the standalone remotes/ URL with ?research-scenario=, alongside the host-composed path.
 const view = parseRouteView(
-  new URLSearchParams(window.location.search).get("research-scenario"),
+  new URLSearchParams(window.location.search).get(routeViewQueryKeys.research),
 );
 const initialState: ResearchViewState | undefined =
   view === "loading" || view === "error"

--- a/apps/research/src/use-research-page.ts
+++ b/apps/research/src/use-research-page.ts
@@ -1,9 +1,5 @@
 import { cvDataClient, type Research } from "@site/data-access-core";
-import {
-  type AsyncViewState,
-  parseRouteView,
-  routeStateQueryKeys,
-} from "@site/route-state";
+import type { AsyncViewState } from "@site/route-state";
 import { useEffect, useState } from "react";
 
 export type ResearchViewState = AsyncViewState<Research>;
@@ -11,22 +7,13 @@ export type ResearchViewState = AsyncViewState<Research>;
 export function useResearchPage(
   initialState?: ResearchViewState,
 ): ResearchViewState {
-  const [state, setState] = useState<ResearchViewState>(() => {
-    if (initialState) return initialState;
-    const view = parseRouteView(
-      typeof window === "undefined"
-        ? undefined
-        : new URLSearchParams(window.location.search).get(
-            routeStateQueryKeys.research,
-          ),
-    );
-    if (view === "loading" || view === "error") return { name: view };
-    if (view === "empty") return { name: "ready", value: { projects: [] } };
-    return {
-      name: "ready",
-      value: cvDataClient.domain("research"),
-    };
-  });
+  const [state, setState] = useState<ResearchViewState>(
+    () =>
+      initialState ?? {
+        name: "ready",
+        value: cvDataClient.domain("research"),
+      },
+  );
   useEffect(() => {
     if (state.name !== "loading") return;
     const timer = window.setTimeout(

--- a/apps/shell-e2e/src/site.spec.ts
+++ b/apps/shell-e2e/src/site.spec.ts
@@ -264,7 +264,7 @@ test("navigation works with the keyboard", async ({ page }) => {
   ).toBeVisible();
 });
 
-// llmlint: ignore-block[tests_mirror_real_usage] Hydration warnings and full-document SPA regressions are explicit acceptance criteria that are observable only through browser console/error and request instrumentation; navigation and focus still use real user-facing controls.
+// llmlint: ignore-block[tests_mirror_real_usage] Hydration warnings, full-document SPA regressions, and whether a prerendered document was hydrated or replaced are explicit acceptance criteria that are observable only through browser console/error, request, and DOM-mutation instrumentation; navigation, focus, and every content assertion still use real user-facing controls.
 test("leaf routes reuse prerendered DOM without hydration warnings and navigate as an SPA", async ({
   browser,
 }) => {
@@ -311,6 +311,74 @@ test("query-only route states client-mount without hydration warnings", async ({
   await expect(
     page.getByRole("heading", { name: "No research projects yet" }),
   ).toBeVisible();
+  expect(errors).toEqual([]);
+});
+
+// Hydrating a prerendered document and throwing it away to client-render the
+// same page produce identical output, so the only way to tell them apart is to
+// watch whether the prerendered children of #root survive. The observer is
+// installed before the shell's deferred entry script runs.
+const rootRemovalKey = "__prerenderedRootRemovals";
+
+async function watchPrerenderedRoot(page: Page) {
+  await page.addInitScript((key: string) => {
+    Reflect.set(window, key, 0);
+    new MutationObserver((records) => {
+      for (const record of records)
+        if (record.target instanceof Element && record.target.id === "root")
+          Reflect.set(
+            window,
+            key,
+            Number(Reflect.get(window, key)) + record.removedNodes.length,
+          );
+    }).observe(document, { childList: true, subtree: true });
+  }, rootRemovalKey);
+  return () =>
+    page.evaluate(
+      (key: string) => Number(Reflect.get(window, key)),
+      rootRemovalKey,
+    );
+}
+
+test("a route reached with a tracking parameter hydrates its prerendered document", async ({
+  page,
+}) => {
+  const errors: string[] = [];
+  page.on("console", (message) => {
+    if (message.type() === "error") errors.push(message.text());
+  });
+  page.on("pageerror", (error) => errors.push(error.message));
+  const removedFromRoot = await watchPrerenderedRoot(page);
+
+  await page.goto("bio?utm_source=newsletter&fbclid=abc123", {
+    waitUntil: "networkidle",
+  });
+  await expect(
+    page.getByRole("heading", { name: "Optimizing Life" }),
+  ).toBeVisible();
+  await expect(page.getByRole("banner")).toBeVisible();
+  expect(await removedFromRoot()).toBe(0);
+  expect(errors).toEqual([]);
+});
+
+test("a route reached with a view override client-renders that view", async ({
+  page,
+}) => {
+  const errors: string[] = [];
+  page.on("console", (message) => {
+    if (message.type() === "error") errors.push(message.text());
+  });
+  page.on("pageerror", (error) => errors.push(error.message));
+  const removedFromRoot = await watchPrerenderedRoot(page);
+
+  await page.goto("bio?bio-view=empty&utm_source=newsletter", {
+    waitUntil: "networkidle",
+  });
+  await expect(page.getByRole("status")).toContainText("Biography coming soon");
+  await expect(page.getByRole("article")).toHaveCount(0);
+  // The static document holds the full biography, so this view is only
+  // reachable by replacing it.
+  expect(await removedFromRoot()).toBeGreaterThan(0);
   expect(errors).toEqual([]);
 });
 

--- a/apps/shell-e2e/src/site.spec.ts
+++ b/apps/shell-e2e/src/site.spec.ts
@@ -264,7 +264,6 @@ test("navigation works with the keyboard", async ({ page }) => {
   ).toBeVisible();
 });
 
-// llmlint: ignore-block[tests_mirror_real_usage] Hydration warnings, full-document SPA regressions, and whether a prerendered document was hydrated or replaced are explicit acceptance criteria that are observable only through browser console/error, request, and DOM-mutation instrumentation; navigation, focus, and every content assertion still use real user-facing controls.
 test("leaf routes reuse prerendered DOM without hydration warnings and navigate as an SPA", async ({
   browser,
 }) => {
@@ -316,71 +315,113 @@ test("query-only route states client-mount without hydration warnings", async ({
 
 // Hydrating a prerendered document and throwing it away to client-render the
 // same page produce identical output, so the only way to tell them apart is to
-// watch whether the prerendered children of #root survive. The observer is
+// watch whether the prerendered main landmark survives: client rendering
+// empties the application root, taking the landmark with it. The observer is
 // installed before the shell's deferred entry script runs.
-const rootRemovalKey = "__prerenderedRootRemovals";
+const landmarkRemovalKey = "__prerenderedMainRemovals";
 
-async function watchPrerenderedRoot(page: Page) {
+// llmlint: ignore-block[tests_mirror_real_usage] Hydration and replacement produce the same visible page, so preserving the prerendered DOM identity—the explicit acceptance criterion—cannot be distinguished through user-visible output. This helper observes only removal of the accessible main landmark; route content is still asserted through roles below.
+async function watchPrerenderedMain(page: Page) {
+  // llmlint: ignore-block[e2e_uses_accessible_selectors] A MutationObserver receives detached nodes, which Playwright's role-based locators cannot reach by definition; matching the main landmark element is the closest available equivalent. Every assertion about what the visitor sees still uses getByRole.
   await page.addInitScript((key: string) => {
     Reflect.set(window, key, 0);
     new MutationObserver((records) => {
       for (const record of records)
-        if (record.target instanceof Element && record.target.id === "root")
-          Reflect.set(
-            window,
-            key,
-            Number(Reflect.get(window, key)) + record.removedNodes.length,
-          );
+        for (const node of record.removedNodes)
+          if (
+            node instanceof Element &&
+            (node.matches("main") || node.querySelector("main"))
+          )
+            Reflect.set(window, key, Number(Reflect.get(window, key)) + 1);
     }).observe(document, { childList: true, subtree: true });
-  }, rootRemovalKey);
+  }, landmarkRemovalKey);
+  // llmlint: ignore-end[e2e_uses_accessible_selectors]
   return () =>
     page.evaluate(
       (key: string) => Number(Reflect.get(window, key)),
-      rootRemovalKey,
+      landmarkRemovalKey,
     );
 }
+// llmlint: ignore-end[tests_mirror_real_usage]
 
-test("a route reached with a tracking parameter hydrates its prerendered document", async ({
-  page,
-}) => {
-  const errors: string[] = [];
-  page.on("console", (message) => {
-    if (message.type() === "error") errors.push(message.text());
-  });
-  page.on("pageerror", (error) => errors.push(error.message));
-  const removedFromRoot = await watchPrerenderedRoot(page);
+// Each leaf route owns a view-override parameter, and every one of them is
+// reachable from search, social, and email with tracking parameters attached.
+const leafRoutes = [
+  {
+    path: "bio",
+    heading: "Optimizing Life",
+    override: "bio-view=empty",
+    overrideHeading: "Biography coming soon",
+  },
+  {
+    path: "research",
+    heading: "Research Works",
+    override: "research-scenario=empty",
+    overrideHeading: "No research projects yet",
+  },
+  {
+    path: "software",
+    heading: "Open-Source Software",
+    override: "software-view=empty",
+    overrideHeading: "No software projects to show",
+  },
+  {
+    path: "courses",
+    heading: "Courses",
+    override: "courses-view=empty",
+    overrideHeading: "No courses to show",
+  },
+  // Preserve each route's literal heading and query pair for its parameterized
+  // accessible assertions instead of widening every field to string.
+] as const;
 
-  await page.goto("bio?utm_source=newsletter&fbclid=abc123", {
-    waitUntil: "networkidle",
-  });
-  await expect(
-    page.getByRole("heading", { name: "Optimizing Life" }),
-  ).toBeVisible();
-  await expect(page.getByRole("banner")).toBeVisible();
-  expect(await removedFromRoot()).toBe(0);
-  expect(errors).toEqual([]);
-});
+for (const route of leafRoutes) {
+  test(`${route.path} reached with a tracking parameter hydrates its prerendered document`, async ({
+    page,
+  }) => {
+    const errors: string[] = [];
+    page.on("console", (message) => {
+      if (message.type() === "error") errors.push(message.text());
+    });
+    page.on("pageerror", (error) => errors.push(error.message));
+    const removedMainLandmarks = await watchPrerenderedMain(page);
 
-test("a route reached with a view override client-renders that view", async ({
-  page,
-}) => {
-  const errors: string[] = [];
-  page.on("console", (message) => {
-    if (message.type() === "error") errors.push(message.text());
+    await page.goto(`${route.path}?utm_source=newsletter&fbclid=abc123`, {
+      waitUntil: "networkidle",
+    });
+    await expect(
+      page.getByRole("heading", { name: route.heading, exact: true }),
+    ).toBeVisible();
+    await expect(page.getByRole("banner")).toBeVisible();
+    // llmlint: ignore[tests_mirror_real_usage] A zero removal count is the identity proof that the prerendered main landmark was hydrated; the resulting page is visibly identical if React replaces it.
+    expect(await removedMainLandmarks()).toBe(0);
+    expect(errors).toEqual([]);
   });
-  page.on("pageerror", (error) => errors.push(error.message));
-  const removedFromRoot = await watchPrerenderedRoot(page);
 
-  await page.goto("bio?bio-view=empty&utm_source=newsletter", {
-    waitUntil: "networkidle",
+  test(`${route.path} reached with a view override client-renders that view`, async ({
+    page,
+  }) => {
+    const errors: string[] = [];
+    page.on("console", (message) => {
+      if (message.type() === "error") errors.push(message.text());
+    });
+    page.on("pageerror", (error) => errors.push(error.message));
+    const removedMainLandmarks = await watchPrerenderedMain(page);
+
+    await page.goto(`${route.path}?${route.override}&utm_source=newsletter`, {
+      waitUntil: "networkidle",
+    });
+    await expect(
+      page.getByRole("heading", { name: route.overrideHeading, exact: true }),
+    ).toBeVisible();
+    await expect(page.getByRole("article")).toHaveCount(0);
+    // The static document holds the default view, so an override is only
+    // reachable by replacing it.
+    // llmlint: ignore[tests_mirror_real_usage] A positive removal count proves the intentionally different view replaced the prerendered landmark; visible empty-state assertions alone cannot distinguish replacement from hydration.
+    expect(await removedMainLandmarks()).toBeGreaterThan(0);
+    expect(errors).toEqual([]);
   });
-  await expect(page.getByRole("status")).toContainText("Biography coming soon");
-  await expect(page.getByRole("article")).toHaveCount(0);
-  // The static document holds the full biography, so this view is only
-  // reachable by replacing it.
-  expect(await removedFromRoot()).toBeGreaterThan(0);
-  expect(errors).toEqual([]);
-});
+}
 
 test("Home reuses prerendered content without hydration warnings", async ({
   page,
@@ -400,8 +441,6 @@ test("Home reuses prerendered content without hydration warnings", async ({
   ).toBeVisible();
   expect(errors).toEqual([]);
 });
-// llmlint: ignore-end[tests_mirror_real_usage]
-
 test("the static 404 is intentional and the router recovers unknown routes", async ({
   browser,
   page,

--- a/apps/shell/rspack.config.ts
+++ b/apps/shell/rspack.config.ts
@@ -2,14 +2,12 @@ import { ModuleFederationPlugin } from "@module-federation/enhanced/rspack";
 import { NxAppRspackPlugin } from "@nx/rspack/app-plugin.js";
 import { NxReactRspackPlugin } from "@nx/rspack/react-plugin.js";
 import { remoteMap } from "@site/build-config";
-import { TanStackRouterGeneratorRspack } from "@tanstack/router-plugin/rspack";
 
 const base = "/nick-derobertis-site/";
 export default {
   entry: "./apps/shell/src/main.tsx",
   output: { publicPath: base, uniqueName: "shell", clean: true },
   plugins: [
-    TanStackRouterGeneratorRspack({ enableRouteGeneration: false }),
     new NxAppRspackPlugin({
       tsConfig: "apps/shell/tsconfig.app.json",
       main: "apps/shell/src/main.tsx",

--- a/apps/shell/src/main.tsx
+++ b/apps/shell/src/main.tsx
@@ -50,6 +50,8 @@ const pages: RoutePages = {
 const router = createSiteRouter({
   history: createBrowserHistory(),
   pages,
+  // The validator returns the domain selected by `name`; the router's generic
+  // callback performs that name-to-return-type narrowing at each call site.
   context: { loadDomain: async (name) => loadBrowserDomain(name) as never },
 });
 function hasSerializedRouter(value: unknown): value is {

--- a/apps/shell/src/main.tsx
+++ b/apps/shell/src/main.tsx
@@ -8,6 +8,7 @@ import {
   loadBrowserDomain,
   type RoutePage,
   type RoutePages,
+  rendersPrerenderedDocument,
   routePath,
 } from "./router";
 import "@site/design-system";
@@ -49,10 +50,7 @@ const pages: RoutePages = {
 const router = createSiteRouter({
   history: createBrowserHistory(),
   pages,
-  context: {
-    loadDomain: async (name) => loadBrowserDomain(name) as never,
-    search: new URLSearchParams(window.location.search),
-  },
+  context: { loadDomain: async (name) => loadBrowserDomain(name) as never },
 });
 function hasSerializedRouter(value: unknown): value is {
   router: Record<string, unknown>;
@@ -62,7 +60,7 @@ function hasSerializedRouter(value: unknown): value is {
   return Boolean(serializedRouter && typeof serializedRouter === "object");
 }
 const hasStaticPayload = hasSerializedRouter(Reflect.get(window, "$_TSR"));
-const canHydrate = hasStaticPayload && !window.location.search;
+const canHydrate = hasStaticPayload && rendersPrerenderedDocument(router);
 if (!canHydrate) await router.load();
 const app = (
   <StrictMode>

--- a/apps/shell/src/router.tsx
+++ b/apps/shell/src/router.tsx
@@ -15,6 +15,7 @@ import {
   prerenderRouteAttribute,
   type ResearchPageProps,
   type RouteView,
+  routeViewQueryKeys,
   routeViews,
   type SoftwarePageProps,
 } from "@site/route-state";
@@ -152,9 +153,11 @@ export function createSiteRouter({
     getParentRoute: () => Root,
     path: routePath("Bio"),
     validateSearch: (search: Record<string, unknown>) => ({
-      "bio-view": viewOverride(search, "bio-view"),
+      [routeViewQueryKeys.bio]: viewOverride(search, routeViewQueryKeys.bio),
     }),
-    loaderDeps: ({ search }) => ({ view: search["bio-view"] ?? "default" }),
+    loaderDeps: ({ search }) => ({
+      view: search[routeViewQueryKeys.bio] ?? "default",
+    }),
     loader: ({ deps }) => deps,
     component: routeComponent(pages.bio, (Page) => {
       const data = bio.useLoaderData();
@@ -165,10 +168,13 @@ export function createSiteRouter({
     getParentRoute: () => Root,
     path: routePath("Research"),
     validateSearch: (search: Record<string, unknown>) => ({
-      "research-scenario": viewOverride(search, "research-scenario"),
+      [routeViewQueryKeys.research]: viewOverride(
+        search,
+        routeViewQueryKeys.research,
+      ),
     }),
     loaderDeps: ({ search }) => ({
-      view: search["research-scenario"] ?? "default",
+      view: search[routeViewQueryKeys.research] ?? "default",
     }),
     loader: async ({ context: ctx, deps: { view } }) => {
       if (view === "loading" || view === "error")
@@ -202,10 +208,13 @@ export function createSiteRouter({
     getParentRoute: () => Root,
     path: routePath("Software"),
     validateSearch: (search: Record<string, unknown>) => ({
-      "software-view": viewOverride(search, "software-view"),
+      [routeViewQueryKeys.software]: viewOverride(
+        search,
+        routeViewQueryKeys.software,
+      ),
     }),
     loaderDeps: ({ search }) => ({
-      view: search["software-view"] ?? "default",
+      view: search[routeViewQueryKeys.software] ?? "default",
     }),
     loader: async ({ context: ctx, deps: { view } }) => {
       if (view === "loading" || view === "error")
@@ -232,9 +241,14 @@ export function createSiteRouter({
     getParentRoute: () => Root,
     path: routePath("Courses"),
     validateSearch: (search: Record<string, unknown>) => ({
-      "courses-view": viewOverride(search, "courses-view"),
+      [routeViewQueryKeys.courses]: viewOverride(
+        search,
+        routeViewQueryKeys.courses,
+      ),
     }),
-    loaderDeps: ({ search }) => ({ view: search["courses-view"] ?? "default" }),
+    loaderDeps: ({ search }) => ({
+      view: search[routeViewQueryKeys.courses] ?? "default",
+    }),
     loader: async ({ context: ctx, deps: { view } }) => {
       if (view === "loading" || view === "error")
         return { courses: null, view };

--- a/apps/shell/src/router.tsx
+++ b/apps/shell/src/router.tsx
@@ -12,10 +12,10 @@ import { SiteLayout } from "@site/layout";
 import {
   type BioPageProps,
   type CoursesPageProps,
-  parseRouteView,
   prerenderRouteAttribute,
   type ResearchPageProps,
-  routeStateQueryKeys,
+  type RouteView,
+  routeViews,
   type SoftwarePageProps,
 } from "@site/route-state";
 import {
@@ -79,7 +79,19 @@ interface RouterContext {
   loadDomain(name: "research"): Promise<Research>;
   loadDomain(name: "software_projects"): Promise<SoftwareProjects>;
   loadDomain(name: "courses"): Promise<Courses>;
-  search: URLSearchParams;
+}
+
+/**
+ * Reads a route's view-override parameter out of a raw query string. Returning
+ * undefined for everything else is what keeps the rest of a query string —
+ * `utm_source`, `fbclid`, `ref` — out of the route's rendered output, and out
+ * of the links the router builds from this location.
+ */
+function viewOverride(
+  search: Record<string, unknown>,
+  key: string,
+): RouteView | undefined {
+  return routeViews.find((view) => view === search[key]);
 }
 
 // Warmed logos are kept alive here so the browser cannot collect an in-flight
@@ -139,9 +151,11 @@ export function createSiteRouter({
   const bio = createRoute({
     getParentRoute: () => Root,
     path: routePath("Bio"),
-    loader: ({ context: ctx }) => ({
-      view: parseRouteView(ctx.search.get(routeStateQueryKeys.bio)),
+    validateSearch: (search: Record<string, unknown>) => ({
+      "bio-view": viewOverride(search, "bio-view"),
     }),
+    loaderDeps: ({ search }) => ({ view: search["bio-view"] ?? "default" }),
+    loader: ({ deps }) => deps,
     component: routeComponent(pages.bio, (Page) => {
       const data = bio.useLoaderData();
       return <Page initialView={data.view} />;
@@ -150,8 +164,13 @@ export function createSiteRouter({
   const research = createRoute({
     getParentRoute: () => Root,
     path: routePath("Research"),
-    loader: async ({ context: ctx }) => {
-      const view = parseRouteView(ctx.search.get(routeStateQueryKeys.research));
+    validateSearch: (search: Record<string, unknown>) => ({
+      "research-scenario": viewOverride(search, "research-scenario"),
+    }),
+    loaderDeps: ({ search }) => ({
+      view: search["research-scenario"] ?? "default",
+    }),
+    loader: async ({ context: ctx, deps: { view } }) => {
       if (view === "loading" || view === "error")
         return { research: null, view };
       try {
@@ -182,8 +201,13 @@ export function createSiteRouter({
   const software = createRoute({
     getParentRoute: () => Root,
     path: routePath("Software"),
-    loader: async ({ context: ctx }) => {
-      const view = parseRouteView(ctx.search.get(routeStateQueryKeys.software));
+    validateSearch: (search: Record<string, unknown>) => ({
+      "software-view": viewOverride(search, "software-view"),
+    }),
+    loaderDeps: ({ search }) => ({
+      view: search["software-view"] ?? "default",
+    }),
+    loader: async ({ context: ctx, deps: { view } }) => {
       if (view === "loading" || view === "error")
         return { projects: null, view };
       try {
@@ -207,8 +231,11 @@ export function createSiteRouter({
   const courses = createRoute({
     getParentRoute: () => Root,
     path: routePath("Courses"),
-    loader: async ({ context: ctx }) => {
-      const view = parseRouteView(ctx.search.get(routeStateQueryKeys.courses));
+    validateSearch: (search: Record<string, unknown>) => ({
+      "courses-view": viewOverride(search, "courses-view"),
+    }),
+    loaderDeps: ({ search }) => ({ view: search["courses-view"] ?? "default" }),
+    loader: async ({ context: ctx, deps: { view } }) => {
       if (view === "loading" || view === "error")
         return { courses: null, view };
       try {
@@ -274,6 +301,34 @@ export function entryRoutePath(root: Element): string | undefined {
     : window.location.pathname;
   const candidate = stamped ?? (pathname === "" ? "/" : pathname);
   return routes.find((route) => route.path === candidate)?.path;
+}
+
+/**
+ * Reports whether the browser's location still renders the document the
+ * prerender step produced, so the shell can hydrate it instead of discarding
+ * it. Every route is prerendered with an empty query string, and the route
+ * `validateSearch` above is what turns a query string into rendered output: a
+ * view override genuinely changes the markup, while a tracking parameter
+ * leaves it identical and must not cost the visitor their prerendered HTML.
+ *
+ * Home is the conservative exception. Its panes are separate remotes that each
+ * read their own state parameter straight from the URL rather than through
+ * this router, so the shell cannot tell an inert parameter from a pane
+ * override there.
+ */
+export function rendersPrerenderedDocument(router: SiteRouter): boolean {
+  const { pathname, search } = router.state.location;
+  const matches = router.matchRoutes(pathname, search);
+  const leaf = matches[matches.length - 1];
+  if (leaf?.fullPath === routePath("Home"))
+    return Object.keys(search).length === 0;
+  const deps: unknown = leaf?.loaderDeps;
+  return (
+    !deps ||
+    typeof deps !== "object" ||
+    !("view" in deps) ||
+    deps.view === "default"
+  );
 }
 
 export async function loadBrowserDomain<

--- a/apps/software/src/main.tsx
+++ b/apps/software/src/main.tsx
@@ -1,5 +1,5 @@
 import "@site/design-system";
-import { parseRouteView } from "@site/route-state";
+import { parseRouteView, routeViewQueryKeys } from "@site/route-state";
 import { lazy, Suspense } from "react";
 import { createRoot } from "react-dom/client";
 import Skeleton from "./skeleton";
@@ -11,8 +11,9 @@ if (!root) throw new Error("Missing remote root");
 // The standalone boundary has no router, so this entry is where the view
 // override is read; the shell's route validates the same parameter through
 // validateSearch and hands the result to the same prop.
+// llmlint: ignore[changed_behavior_has_e2e] software.spec.ts already drives this entry's happy, empty, loading, and error states through the standalone remotes/ URL with ?software-view=, alongside the host-composed path.
 const initialView = parseRouteView(
-  new URLSearchParams(window.location.search).get("software-view"),
+  new URLSearchParams(window.location.search).get(routeViewQueryKeys.software),
 );
 createRoot(root).render(
   <Suspense fallback={<Skeleton />}>

--- a/apps/software/src/main.tsx
+++ b/apps/software/src/main.tsx
@@ -1,4 +1,5 @@
 import "@site/design-system";
+import { parseRouteView } from "@site/route-state";
 import { lazy, Suspense } from "react";
 import { createRoot } from "react-dom/client";
 import Skeleton from "./skeleton";
@@ -7,8 +8,14 @@ const Page = lazy(() => import("./page"));
 
 const root = document.getElementById("root");
 if (!root) throw new Error("Missing remote root");
+// The standalone boundary has no router, so this entry is where the view
+// override is read; the shell's route validates the same parameter through
+// validateSearch and hands the result to the same prop.
+const initialView = parseRouteView(
+  new URLSearchParams(window.location.search).get("software-view"),
+);
 createRoot(root).render(
   <Suspense fallback={<Skeleton />}>
-    <Page />
+    <Page initialView={initialView} />
   </Suspense>,
 );

--- a/apps/software/src/use-software-page.ts
+++ b/apps/software/src/use-software-page.ts
@@ -1,25 +1,12 @@
 import { cvDataClient, type SoftwareProject } from "@site/data-access-core";
-import {
-  parseRouteView,
-  type RouteView,
-  routeStateQueryKeys,
-} from "@site/route-state";
+import type { RouteView } from "@site/route-state";
 import { useEffect, useState } from "react";
 
 export function useSoftwarePage(
   initialView?: RouteView,
   initialProjects?: SoftwareProject[],
 ) {
-  const [view, setView] = useState<RouteView>(() =>
-    parseRouteView(
-      initialView ??
-        (typeof window === "undefined"
-          ? undefined
-          : new URLSearchParams(window.location.search).get(
-              routeStateQueryKeys.software,
-            )),
-    ),
-  );
+  const [view, setView] = useState<RouteView>(initialView ?? "default");
   useEffect(() => {
     if (view !== "loading") return;
     const timer = window.setTimeout(() => setView("default"), 1_500);

--- a/libs/route-state/src/contracts.json
+++ b/libs/route-state/src/contracts.json
@@ -1,9 +1,3 @@
 {
-  "queryKeys": {
-    "bio": "bio-view",
-    "research": "research-scenario",
-    "software": "software-view",
-    "courses": "courses-view"
-  },
   "prerenderRouteAttribute": "data-prerendered-route"
 }

--- a/libs/route-state/src/index.ts
+++ b/libs/route-state/src/index.ts
@@ -3,16 +3,9 @@ import contractInput from "./contracts.json";
 
 const contracts = z
   .object({
-    queryKeys: z.object({
-      bio: z.string().min(1),
-      research: z.string().min(1),
-      software: z.string().min(1),
-      courses: z.string().min(1),
-    }),
     prerenderRouteAttribute: z.string().regex(/^data-[a-z-]+$/),
   })
   .parse(contractInput);
-export const routeStateQueryKeys = contracts.queryKeys;
 export const prerenderRouteAttribute = contracts.prerenderRouteAttribute;
 
 export type AsyncViewState<T> =

--- a/libs/route-state/src/index.ts
+++ b/libs/route-state/src/index.ts
@@ -16,6 +16,20 @@ export type AsyncViewState<T> =
 export const routeViews = ["default", "empty", "error", "loading"] as const;
 export type RouteView = (typeof routeViews)[number];
 
+/**
+ * The query parameter each route takes its view override from. The shell
+ * validates it through the router while the standalone remote reads it in its
+ * own entry, because that boundary has no router — so the two boundaries parse
+ * separately but must agree on the key, and this is where they agree.
+ */
+export const routeViewQueryKeys = {
+  bio: "bio-view",
+  research: "research-scenario",
+  software: "software-view",
+  courses: "courses-view",
+  // Computed router search keys need these values to remain string literals.
+} as const;
+
 export function parseRouteView(value: string | null | undefined): RouteView {
   return routeViews.find((view) => view === value) ?? "default";
 }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "@playwright/test": "1.61.1",
     "@swc-node/register": "1.12.1",
     "@swc/core": "1.15.46",
-    "@tanstack/router-plugin": "1.168.23",
     "@testing-library/jest-dom": "6.9.1",
     "@testing-library/react": "16.3.2",
     "@types/node": "26.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,9 +72,6 @@ importers:
       '@swc/core':
         specifier: 1.15.46
         version: 1.15.46(@swc/helpers@0.5.23)
-      '@tanstack/router-plugin':
-        specifier: 1.168.23
-        version: 1.168.23(@rspack/core@1.7.12(@swc/helpers@0.5.23))(@tanstack/react-router@1.170.18(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(rolldown@1.1.5)(rollup@4.62.2)(vite@8.1.5(@types/node@26.1.1)(jiti@2.7.0)(less@4.7.0)(sass-embedded@1.100.0)(sass@1.101.0)(terser@5.49.0)(yaml@2.9.0))(webpack@5.105.2(@swc/core@1.15.46(@swc/helpers@0.5.23))(postcss@8.5.20))
       '@testing-library/jest-dom':
         specifier: 6.9.1
         version: 6.9.1
@@ -2526,41 +2523,8 @@ packages:
     resolution: {integrity: sha512-IILCDcLaItMZQ2jEmCABHY1Nhjjn5XUvwpQp3e4Nmu+vfg0BgYFuu/QASz2SwE2ZNbVMrvt8X/wxa+Gg5aErxA==}
     engines: {node: '>=20.19'}
 
-  '@tanstack/router-generator@1.167.21':
-    resolution: {integrity: sha512-m3oXZyienj8owialdyoZ0txHQrnEx/Ra+D9kWtar5fC2cWZr5Pvxl86VY2mX5RRLC5QLKLeRGT1x4HV95wHVDQ==}
-    engines: {node: '>=20.19'}
-
-  '@tanstack/router-plugin@1.168.23':
-    resolution: {integrity: sha512-0+PIcvnaAimFwjoEIeV3h7LKjzC8zNnp7pH2UamdKwQ9QlY99WU9V0Xl0zbM0i9hrUa/mKgWPDAzELmPUu5fMA==}
-    engines: {node: '>=20.19'}
-    peerDependencies:
-      '@rsbuild/core': '>=1.0.2 || ^2.0.0'
-      '@tanstack/react-router': ^1.170.18
-      vite: '>=5.0.0 || >=6.0.0 || >=7.0.0 || >=8.0.0'
-      vite-plugin-solid: ^2.11.10 || ^3.0.0-0
-      webpack: '>=5.92.0'
-    peerDependenciesMeta:
-      '@rsbuild/core':
-        optional: true
-      '@tanstack/react-router':
-        optional: true
-      vite:
-        optional: true
-      vite-plugin-solid:
-        optional: true
-      webpack:
-        optional: true
-
-  '@tanstack/router-utils@1.162.2':
-    resolution: {integrity: sha512-hTWqJtqIFFdvuCl8WXNyrodp2L9zo2G37xKRrcVmVRWpAB2h+U1LuRAfS4tsFTiWOIoE/B+WDVFB8JpoEdw6jQ==}
-    engines: {node: '>=20.19'}
-
   '@tanstack/store@0.9.3':
     resolution: {integrity: sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw==}
-
-  '@tanstack/virtual-file-routes@1.162.0':
-    resolution: {integrity: sha512-uhOeFyxLcU41HzvrxsGpiWdcMbScY1EDgbZ5K7DVRMYInbLYWAC0EA/kx9wXAoSM8q82bUG2hRl8+EAjE6XAbA==}
-    engines: {node: '>=20.19'}
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -2974,10 +2938,6 @@ packages:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
     engines: {node: '>=10'}
 
-  ansis@4.3.1:
-    resolution: {integrity: sha512-BJ8/l4R5LRE7hW9WdSuGYrLSHi2ynxeFpDFbH0K/CgNeY/tyhk+vO6TYxXC5r5CpUhNVX310xzPsN/H9lCdfOA==}
-    engines: {node: '>=14'}
-
   anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
@@ -3036,9 +2996,6 @@ packages:
     peerDependenciesMeta:
       react-native-b4a:
         optional: true
-
-  babel-dead-code-elimination@1.0.12:
-    resolution: {integrity: sha512-GERT7L2TiYcYDtYk1IpD+ASAYXjKbLTDPhBtYj7X1NuRMDTMtAx9kyBenub1Ev41lo91OHCKdmP+egTDmfQ7Ig==}
 
   babel-plugin-const-enum@1.2.0:
     resolution: {integrity: sha512-o1m/6iyyFnp9MRsK1dHF3bneqyf3AlM2q3A/YbgQr2pCat6B6XJVDv2TXqzfY2RYUi4mak6WAksSBPlyYGx9dg==}
@@ -3548,10 +3505,6 @@ packages:
 
   devtools-protocol@0.0.1608973:
     resolution: {integrity: sha512-Tpm17fxYzt+J7VrGdc1k8YdRqS3YV7se/M6KeemEqvUbq/n7At1rWVuXMxQgpWkdwSdIEKYbU//Bve+Shm4YNQ==}
-
-  diff@8.0.4:
-    resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
-    engines: {node: '>=0.3.1'}
 
   dns-packet@5.6.1:
     resolution: {integrity: sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw==}
@@ -4924,11 +4877,6 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
-  prettier@3.9.6:
-    resolution: {integrity: sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==}
-    engines: {node: '>=14'}
-    hasBin: true
-
   pretty-format@27.5.1:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
@@ -5721,39 +5669,6 @@ packages:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
 
-  unplugin@3.3.0:
-    resolution: {integrity: sha512-qa66K+crbfyE6JK10GjvbJeRrOsuC/JpbnHctfyp/i4oBTxWOzJfRZyDiOk1PtErMFRu8JhsU/wPvOdBNWe5Rg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    peerDependencies:
-      '@farmfe/core': '*'
-      '@rspack/core': '*'
-      bun-types-no-globals: '*'
-      esbuild: '*'
-      rolldown: '*'
-      rollup: '*'
-      unloader: '*'
-      vite: '*'
-      webpack: '*'
-    peerDependenciesMeta:
-      '@farmfe/core':
-        optional: true
-      '@rspack/core':
-        optional: true
-      bun-types-no-globals:
-        optional: true
-      esbuild:
-        optional: true
-      rolldown:
-        optional: true
-      rollup:
-        optional: true
-      unloader:
-        optional: true
-      vite:
-        optional: true
-      webpack:
-        optional: true
-
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
     hasBin: true
@@ -5914,9 +5829,6 @@ packages:
   webpack-sources@3.5.1:
     resolution: {integrity: sha512-jyuiGJdtvY434z5bUZrjz67v76/ePNvFZTp9Mdz29IlH4+GPsgyGjiv0fKI+M7BdkU6ADjulUcKAd3tUK3WlEw==}
     engines: {node: '>=10.13.0'}
-
-  webpack-virtual-modules@0.6.2:
-    resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
 
   webpack@5.105.2:
     resolution: {integrity: sha512-dRXm0a2qcHPUBEzVk8uph0xWSjV/xZxenQQbLwnwP7caQCYpqG1qddwlyEkIDkYn0K8tvmcrZ+bOrzoQ3HxCDw==}
@@ -8912,60 +8824,7 @@ snapshots:
       seroval: 1.5.6
       seroval-plugins: 1.5.6(seroval@1.5.6)
 
-  '@tanstack/router-generator@1.167.21':
-    dependencies:
-      '@babel/types': 7.29.7
-      '@tanstack/router-core': 1.171.15
-      '@tanstack/router-utils': 1.162.2
-      '@tanstack/virtual-file-routes': 1.162.0
-      jiti: 2.7.0
-      magic-string: 0.30.21
-      prettier: 3.9.6
-      zod: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@tanstack/router-plugin@1.168.23(@rspack/core@1.7.12(@swc/helpers@0.5.23))(@tanstack/react-router@1.170.18(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(rolldown@1.1.5)(rollup@4.62.2)(vite@8.1.5(@types/node@26.1.1)(jiti@2.7.0)(less@4.7.0)(sass-embedded@1.100.0)(sass@1.101.0)(terser@5.49.0)(yaml@2.9.0))(webpack@5.105.2(@swc/core@1.15.46(@swc/helpers@0.5.23))(postcss@8.5.20))':
-    dependencies:
-      '@babel/core': 7.29.7
-      '@babel/template': 7.29.7
-      '@babel/types': 7.29.7
-      '@tanstack/router-core': 1.171.15
-      '@tanstack/router-generator': 1.167.21
-      '@tanstack/router-utils': 1.162.2
-      chokidar: 5.0.0
-      unplugin: 3.3.0(@rspack/core@1.7.12(@swc/helpers@0.5.23))(rolldown@1.1.5)(rollup@4.62.2)(vite@8.1.5(@types/node@26.1.1)(jiti@2.7.0)(less@4.7.0)(sass-embedded@1.100.0)(sass@1.101.0)(terser@5.49.0)(yaml@2.9.0))(webpack@5.105.2(@swc/core@1.15.46(@swc/helpers@0.5.23))(postcss@8.5.20))
-      zod: 4.4.3
-    optionalDependencies:
-      '@tanstack/react-router': 1.170.18(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      vite: 8.1.5(@types/node@26.1.1)(jiti@2.7.0)(less@4.7.0)(sass-embedded@1.100.0)(sass@1.101.0)(terser@5.49.0)(yaml@2.9.0)
-      webpack: 5.105.2(@swc/core@1.15.46(@swc/helpers@0.5.23))(postcss@8.5.20)
-    transitivePeerDependencies:
-      - '@farmfe/core'
-      - '@rspack/core'
-      - bun-types-no-globals
-      - esbuild
-      - rolldown
-      - rollup
-      - supports-color
-      - unloader
-
-  '@tanstack/router-utils@1.162.2':
-    dependencies:
-      '@babel/generator': 7.29.7
-      '@babel/parser': 7.29.7
-      '@babel/types': 7.29.7
-      ansis: 4.3.1
-      babel-dead-code-elimination: 1.0.12
-      diff: 8.0.4
-      pathe: 2.0.3
-      tinyglobby: 0.2.17
-    transitivePeerDependencies:
-      - supports-color
-
   '@tanstack/store@0.9.3': {}
-
-  '@tanstack/virtual-file-routes@1.162.0': {}
 
   '@testing-library/dom@10.4.1':
     dependencies:
@@ -9489,8 +9348,6 @@ snapshots:
 
   ansi-styles@5.2.0: {}
 
-  ansis@4.3.1: {}
-
   anymatch@3.1.3:
     dependencies:
       normalize-path: 3.0.0
@@ -9549,15 +9406,6 @@ snapshots:
       - supports-color
 
   b4a@1.8.1: {}
-
-  babel-dead-code-elimination@1.0.12:
-    dependencies:
-      '@babel/core': 7.29.7
-      '@babel/parser': 7.29.7
-      '@babel/traverse': 7.29.7
-      '@babel/types': 7.29.7
-    transitivePeerDependencies:
-      - supports-color
 
   babel-plugin-const-enum@1.2.0(@babel/core@7.29.7):
     dependencies:
@@ -10069,8 +9917,6 @@ snapshots:
   devtools-protocol@0.0.1507524: {}
 
   devtools-protocol@0.0.1608973: {}
-
-  diff@8.0.4: {}
 
   dns-packet@5.6.1:
     dependencies:
@@ -11621,8 +11467,6 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prettier@3.9.6: {}
-
   pretty-format@27.5.1:
     dependencies:
       ansi-regex: 5.0.1
@@ -12472,18 +12316,6 @@ snapshots:
 
   unpipe@1.0.0: {}
 
-  unplugin@3.3.0(@rspack/core@1.7.12(@swc/helpers@0.5.23))(rolldown@1.1.5)(rollup@4.62.2)(vite@8.1.5(@types/node@26.1.1)(jiti@2.7.0)(less@4.7.0)(sass-embedded@1.100.0)(sass@1.101.0)(terser@5.49.0)(yaml@2.9.0))(webpack@5.105.2(@swc/core@1.15.46(@swc/helpers@0.5.23))(postcss@8.5.20)):
-    dependencies:
-      '@jridgewell/remapping': 2.3.5
-      picomatch: 4.0.5
-      webpack-virtual-modules: 0.6.2
-    optionalDependencies:
-      '@rspack/core': 1.7.12(@swc/helpers@0.5.23)
-      rolldown: 1.1.5
-      rollup: 4.62.2
-      vite: 8.1.5(@types/node@26.1.1)(jiti@2.7.0)(less@4.7.0)(sass-embedded@1.100.0)(sass@1.101.0)(terser@5.49.0)(yaml@2.9.0)
-      webpack: 5.105.2(@swc/core@1.15.46(@swc/helpers@0.5.23))(postcss@8.5.20)
-
   update-browserslist-db@1.2.3(browserslist@4.28.6):
     dependencies:
       browserslist: 4.28.6
@@ -12599,8 +12431,6 @@ snapshots:
   webpack-node-externals@3.0.0: {}
 
   webpack-sources@3.5.1: {}
-
-  webpack-virtual-modules@0.6.2: {}
 
   webpack@5.105.2(@swc/core@1.15.46(@swc/helpers@0.5.23))(postcss@8.5.20):
     dependencies:

--- a/scripts/render-entry.tsx
+++ b/scripts/render-entry.tsx
@@ -82,6 +82,8 @@ export async function renderRoute(path: string) {
           software: { component: SoftwarePage },
           courses: { component: CoursesPage },
         },
+        // The prerender domain table is complete; the router's generic callback
+        // narrows the selected value from its validated domain name.
         context: { loadDomain: async (name) => domains[name] as never },
       }),
   });

--- a/scripts/render-entry.tsx
+++ b/scripts/render-entry.tsx
@@ -82,10 +82,7 @@ export async function renderRoute(path: string) {
           software: { component: SoftwarePage },
           courses: { component: CoursesPage },
         },
-        context: {
-          loadDomain: async (name) => domains[name] as never,
-          search: url.searchParams,
-        },
+        context: { loadDomain: async (name) => domains[name] as never },
       }),
   });
   await handler(async ({ router }) => {

--- a/scripts/route-contracts.mjs
+++ b/scripts/route-contracts.mjs
@@ -3,16 +3,6 @@ import contractInput from "../libs/route-state/src/contracts.json" with {
 };
 
 // llmlint: ignore-block[contracts_have_one_source_or_a_drift_gate] contracts.json is the single serialized source; this plain-Node validator and the TypeScript/Zod validator independently reject invalid boundary input because prerender tooling cannot import workspace TypeScript, and just check executes both consumers.
-const queryKeys = contractInput?.queryKeys;
-if (!queryKeys || typeof queryKeys !== "object")
-  throw new Error(
-    "route-state contracts.json is missing queryKeys; add the four route keys and rerun just check.",
-  );
-for (const name of ["bio", "research", "software", "courses"])
-  if (typeof queryKeys[name] !== "string" || !queryKeys[name])
-    throw new Error(
-      `route-state contracts.json has an invalid ${name} query key; set it to a non-empty string and rerun just check.`,
-    );
 if (
   typeof contractInput.prerenderRouteAttribute !== "string" ||
   !/^data-[a-z-]+$/.test(contractInput.prerenderRouteAttribute)


### PR DESCRIPTION
## Summary
- validate the four leaf-route view overrides through TanStack Router search validation
- parse standalone remote overrides at their entry boundaries and remove URL search from hooks/context
- hydrate prerendered documents with inert tracking parameters while client-rendering genuine view overrides
- remove the disabled TanStack router generator plugin

## Verification
- `just test`
- `bash -lc "just check && just lint-llm-diff"`
