### PR TITLE
refactor(awards): name the empty and error state copy

### DIFF
--- a/apps/awards/src/page.tsx
+++ b/apps/awards/src/page.tsx
@@ -13,7 +13,7 @@ import "./awards.css";
 export { preloadAwards as preload };
 
 function State({ name }: { name: "error" | "empty" }) {
-  const copy =
+  const [heading, detail] =
     name === "error"
       ? [
           "Awards unavailable",
@@ -25,8 +25,8 @@ function State({ name }: { name: "error" | "empty" }) {
       className="awards-state"
       role={name === "error" ? "alert" : "status"}
     >
-      <h2>{copy[0]}</h2>
-      <p>{copy[1]}</p>
+      <h2>{heading}</h2>
+      <p>{detail}</p>
     </section>
   );
 }


### PR DESCRIPTION
## What
Destructure the awards state copy into `heading` and `detail` instead of indexing an anonymous array at `copy[0]` / `copy[1]`.

## Why
Positional indexing hid which string was the heading and which the body at the point of use. Naming them makes the two-state union readable without scrolling back to the literal.

This change is deliberately scoped to `apps/awards/` alone: it doubles as the awards-only probe for the new per-app publish topology landed in #60, which must select exactly one publish lane for a single-app change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)