### PR TITLE
docs(shell): record that the redirect routes are not prerendered

### DIFF
--- a/apps/shell/src/router.tsx
+++ b/apps/shell/src/router.tsx
@@ -268,6 +268,11 @@ export function createSiteRouter({
       );
     }),
   });
+  // `story` and `catchAll` redirect during routing rather than render, so
+  // neither is prerendered and neither owns a directory in the deployed
+  // artifact. A direct request for /story/ therefore returns 404 from Pages by
+  // design, and the redirect applies only once the shell is already running.
+  // The five prerendered routes are home, bio, research, software, and courses.
   const story = createRoute({
     getParentRoute: () => Root,
     path: "/story",


### PR DESCRIPTION
## What
Note at the `story` and `catchAll` route definitions that both redirect during routing rather than render, so neither is prerendered and a direct request for `/story/` returns 404 from Pages by design.

## Why
Nothing at the route definition said this, so a 404 on `/story/` reads as a deploy regression when checking the live site — it cost real time to rule out during verification of the new publish topology. It is not a regression: only home, bio, research, software, and courses own prerendered directories.

Scoped to `apps/shell/` alone: it doubles as the shell-only probe for the per-app publish topology landed in #60, which must run the shell lane and rebuild no remote.

🤖 Generated with [Claude Code](https://claude.com/claude-code)