### PR TITLE
docs(courses): explain the preview loading timer

### DIFF
--- a/apps/courses/src/use-courses-page.ts
+++ b/apps/courses/src/use-courses-page.ts
@@ -7,6 +7,10 @@ export function useCoursesPage(
   initialCourses?: Course[],
 ) {
   const [view, setView] = useState<RouteView>(initialView ?? "default");
+  // `loading` is a preview scenario, not a real fetch state: courses arrive
+  // synchronously from the data client below. The timer resolves it back to
+  // `default` so a previewed skeleton demonstrates itself and then leaves,
+  // rather than sticking for the rest of the session.
   useEffect(() => {
     if (view !== "loading") return;
     const timer = window.setTimeout(() => setView("default"), 1_500);


### PR DESCRIPTION
## What
Note that `loading` is a preview scenario rather than a real fetch state, and that the 1.5s timer exists so a previewed skeleton resolves instead of sticking.

## Why
Courses arrive synchronously from the data client, so an unexplained timer that flips view state reads like a race workaround. Saying what it is prevents someone removing it as dead code or copying it into a pane that does fetch.

Scoped to `apps/courses/` alone. Paired with the `apps/bio/` change so the two publish lanes overlap, exercising the compose-and-deploy `queue: max` / `cancel-in-progress: false` concurrency landed in #60.

🤖 Generated with [Claude Code](https://claude.com/claude-code)