### PR TITLE
fix(just): make lint-llm-diff's first argument a diff base, not a file

### DIFF
--- a/apps/shell-e2e/src/unit/lint-llm-diff.spec.ts
+++ b/apps/shell-e2e/src/unit/lint-llm-diff.spec.ts
@@ -1,0 +1,193 @@
+import { spawnSync } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, expect, test } from "vitest";
+
+// `just lint-llm-diff` is the diff-scoped LLM-judge run, and llmlint's trailing
+// `[FILES]` positional *replaces the configured file globs*. A path it cannot
+// match is not an error: every rule reports "no files matched" and the run exits
+// 0. So an argument that lands on FILES instead of on `--diff-base`, or a single
+// path that word-splits into two unmatchable ones, shrinks the judged ruleset and
+// still reports a pass. These tests drive the real recipe and assert the argv it
+// hands over, which is all the recipe decides.
+
+const DEFAULT_BASE = "origin/master";
+
+interface Invocation {
+  status: number | null;
+  stderr: string;
+  /** The argv llmlint received, or null when the recipe rejected its input first. */
+  argv: string[] | null;
+}
+
+// llmlint: ignore-block[e2e_not_mocked] These tests drive the real `just lint-llm-diff` CLI as a user does; only llmlint, the billed and networked third-party judge downstream of it, is stood in for. Running the real one would spend a model call per case, make a deterministic gate depend on the network, and break `just check` for anyone who has not also run `just setup-llmlint`, which `just bootstrap` does not. The real llmlint is driven by `just lint-llm-diff` itself, which is the gate.
+/**
+ * Runs the recipe with `llmlint` replaced by a stub that records its arguments
+ * NUL-separated, so a recorded argument is exactly the one llmlint received even
+ * when it contains whitespace. The stub's exit code stands in for the judge's
+ * verdict, which is the recipe's only failure input from llmlint.
+ */
+function runLintLlmDiff(args: string[], stubExit = 0): Invocation {
+  const stubDir = mkdtempSync(path.join(tmpdir(), "llmlint-stub-"));
+  try {
+    const argvFile = path.join(stubDir, "argv");
+    writeFileSync(
+      path.join(stubDir, "llmlint"),
+      `#!/usr/bin/env bash\nprintf '%s\\0' "$@" >${JSON.stringify(argvFile)}\nexit ${stubExit}\n`,
+      { mode: 0o755 },
+    );
+    const result = spawnSync("just", ["lint-llm-diff", ...args], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      timeout: 120_000,
+      env: {
+        ...process.env,
+        PATH: `${stubDir}${path.delimiter}${process.env.PATH ?? ""}`,
+      },
+    });
+    const recorded = existsSync(argvFile)
+      ? readFileSync(argvFile, "utf8")
+      : null;
+    return {
+      status: result.status,
+      stderr: result.stderr,
+      argv:
+        recorded === null
+          ? null
+          : recorded === ""
+            ? []
+            : recorded.split("\0").slice(0, -1),
+    };
+  } finally {
+    rmSync(stubDir, { recursive: true, force: true });
+  }
+}
+// llmlint: ignore-end[e2e_not_mocked]
+
+// llmlint: ignore-block[tests_mirror_real_usage] The argv llmlint receives is this recipe's own output, and it is the only observable that can prove the routing: a ref sent to FILES instead of `--diff-base` leaves exit status and stdout looking exactly like a clean run, which is how the bug these tests cover survived a real invocation. Every user-visible outcome the recipe does own — exit 0, the two exit 2 rejections and their messages, and the exit 1 the judge's findings cause — is asserted straight off the CLI alongside it.
+/** The argv llmlint received, refusing to assert on a run that never got there. */
+function judgedArgv({ argv, status, stderr }: Invocation): string[] {
+  if (argv === null)
+    throw new Error(
+      `just lint-llm-diff never reached llmlint (exit ${status}): ${stderr}`,
+    );
+  return argv;
+}
+
+/** Everything llmlint reads as a FILES entry: the argv after the base. */
+function fileOverrides(argv: string[]): string[] {
+  const base = argv.indexOf("--diff-base");
+  if (base === -1) throw new Error("the recipe passed no --diff-base");
+  return argv.slice(base + 2);
+}
+
+describe("just lint-llm-diff argument routing", () => {
+  test("judges the whole configured tree against origin/master by default", () => {
+    const invocation = runLintLlmDiff([]);
+    const argv = judgedArgv(invocation);
+
+    expect(invocation.status).toBe(0);
+    expect(argv).toEqual(["--diff", "--diff-base", DEFAULT_BASE]);
+    expect(fileOverrides(argv)).toEqual([]);
+  });
+
+  test("routes a passed ref to --diff-base and never to FILES", () => {
+    const invocation = runLintLlmDiff(["HEAD~1"]);
+    const argv = judgedArgv(invocation);
+
+    expect(invocation.status).toBe(0);
+    expect(argv).toEqual(["--diff", "--diff-base", "HEAD~1"]);
+    expect(fileOverrides(argv)).toEqual([]);
+  });
+
+  test("accepts a range as the base, which llmlint diffs as given", () => {
+    const invocation = runLintLlmDiff(["HEAD~1..HEAD"]);
+    const argv = judgedArgv(invocation);
+
+    expect(invocation.status).toBe(0);
+    expect(argv).toEqual(["--diff", "--diff-base", "HEAD~1..HEAD"]);
+  });
+
+  test("keeps files available after the base", () => {
+    const invocation = runLintLlmDiff([
+      "HEAD~1",
+      "justfile",
+      "apps/shell-e2e/src/unit",
+    ]);
+
+    expect(invocation.status).toBe(0);
+    expect(judgedArgv(invocation)).toEqual([
+      "--diff",
+      "--diff-base",
+      "HEAD~1",
+      "justfile",
+      "apps/shell-e2e/src/unit",
+    ]);
+  });
+
+  test("hands a path containing a space to llmlint as the one file it names", () => {
+    // The recipe only forwards paths that exist, so this needs a real one. It
+    // goes under the gitignored scratch directory, which Nx does not hash.
+    mkdirSync("test-results", { recursive: true });
+    const scratch = mkdtempSync(path.join("test-results", "lint-llm-diff-"));
+    const spaced = path.join(scratch, "a spaced file.tsx");
+    try {
+      writeFileSync(spaced, "");
+      const invocation = runLintLlmDiff(["HEAD~1", spaced]);
+
+      expect(invocation.status).toBe(0);
+      expect(fileOverrides(judgedArgv(invocation))).toEqual([spaced]);
+    } finally {
+      rmSync(scratch, { recursive: true, force: true });
+    }
+  });
+
+  test.each(["no-such-file.ts", "../package.json", "--plan-only"])(
+    "refuses to judge anything when a file cannot be matched: %s",
+    (file) => {
+      const invocation = runLintLlmDiff(["HEAD~1", file]);
+
+      expect(invocation.status).toBe(2);
+      expect(invocation.argv).toBeNull();
+      expect(invocation.stderr).toContain(
+        "lint-llm-diff: every file after the base must be an existing workspace path",
+      );
+    },
+  );
+
+  test.each(["no-such-ref", "--plan-only"])(
+    "refuses to judge anything when the base is not a revision: %s",
+    (base) => {
+      const invocation = runLintLlmDiff([base]);
+
+      expect(invocation.status).toBe(2);
+      expect(invocation.argv).toBeNull();
+      expect(invocation.stderr).toContain(
+        "lint-llm-diff: base must be a git revision to diff against",
+      );
+    },
+  );
+
+  test("fails the recipe with a next action when the judge reports findings", () => {
+    const invocation = runLintLlmDiff([], 1);
+
+    expect(invocation.status).toBe(1);
+    expect(judgedArgv(invocation)).toEqual([
+      "--diff",
+      "--diff-base",
+      DEFAULT_BASE,
+    ]);
+    expect(invocation.stderr).toContain(
+      "lint-llm-diff: the LLM judge reported the findings above",
+    );
+  });
+});
+// llmlint: ignore-end[tests_mirror_real_usage]

--- a/justfile
+++ b/justfile
@@ -136,8 +136,17 @@ setup-llm-harness:
 lint-llm:
     llmlint
 
-lint-llm-diff *args:
-    llmlint --diff --diff-base "origin/master" {{args}}
+# Judge the branch diff. The first argument is the diff base, not a file:
+# llmlint's trailing FILES positional replaces the configured globs, and a path
+# it cannot match is a silent exit 0, so a ref left there drops most rules and
+# reports a pass over a fraction of the ruleset. Files, when you really want to
+# narrow the run, come after the base; they stay positional so a path that
+# contains a space reaches llmlint as the one file the caller named. Both the
+# base and every file are checked here because llmlint answers an unmatchable
+# path with a clean run, so an argument this recipe gets wrong is invisible.
+# llmlint: ignore[changed_behavior_has_e2e] This developer CLI has no browser interface; it judges the working tree and reports an exit status, so nothing it does is observable to a visitor. lint-llm-diff.spec.ts drives this exact recipe as a real subprocess through the default base, an explicit ref, a range, pass-through files, both rejected-input paths, and a reported-findings failure.
+@lint-llm-diff base="origin/master" *files:
+    base="$1"; [[ "$base" != -* ]] && git rev-list -1 "$base" -- >/dev/null 2>&1 || { echo "lint-llm-diff: base must be a git revision to diff against, such as origin/master, HEAD~1, or a range; fetch the missing ref, then rerun just lint-llm-diff <base>" >&2; exit 2; }; for file in "${@:2}"; do [[ "$file" != -* && "$file" != *..* && -e "$file" ]] || { echo "lint-llm-diff: every file after the base must be an existing workspace path, because llmlint reports a clean run for a path it cannot match; correct or drop \"$file\", then rerun just lint-llm-diff $base <files>" >&2; exit 2; }; done; llmlint --diff --diff-base "$base" "${@:2}" || { echo "lint-llm-diff: the LLM judge reported the findings above; fix each one, or justify it with a narrow ignore directive at its site, then rerun just lint-llm-diff" >&2; exit 1; }
 
 lint-llm-validate *args:
     llmlint validate {{args}}


### PR DESCRIPTION
## What
Publish the change on this branch. It is finished, tested, and needs no rework.

The branch carries `1ee4dda fix(just): make lint-llm-diff's first argument a diff base,
not a file`, plus two harness provenance commits on top — an empty
`chore: orchestrated change (incomplete step)` marker and a
`chore: attest verified recovery of preserved work`.

Your whole job is: run the repository's gate, and let the lifecycle publish the branch.

- **Do not** modify the change, its message, or the two provenance commits.
- **Do not** run `just lint-llm-diff` against the real judge to demonstrate the fix. Its
  behavior is already proven by `apps/shell-e2e/src/unit/lint-llm-diff.spec.ts`, which
  drives the real recipe with a recording stub and asserts the argv it hands over. That
  test runs inside the gate. A live judged run would spend a model call per case and make
  a deterministic check depend on the network, which is exactly what that test's
  `ignore-block[e2e_not_mocked]` justification rejects.
- **Do not** widen scope. If you believe something is wrong with the change, stop and say
  so in your report instead of fixing it.

If the gate passes, you are done — report it and let publication proceed.

## Why
This change has been finished for hours and has failed to land four times, never once
because the change was wrong: one dispatch never ran the gate, one had a commit subject
two characters too long, one ran in a worktree with no workspace install so the pre-push
guard died silently, and one burned its turn cap re-proving what a committed test already
proves. Meanwhile `just lint-llm-diff` remains the pre-push enforcement point in a
repository with no CI, and passing it a ref still silently narrows the run to the subset
of rules whose own `files` globs survive — a confident pass over a fraction of the
ruleset. A false green there is the difference between a gate and the appearance of one.

Orchestrator-Recovered-Incomplete: 08c1c4f2f1f0b5e9bc89ddb97a6041829024a253
